### PR TITLE
[HOTFIX]  Fix documentation redirect to first child

### DIFF
--- a/doc/1/index.md
+++ b/doc/1/index.md
@@ -6,4 +6,4 @@ title: Jvm SDK v1.x
 description: Jvm SDK v1.x
 ---
 
-<redirect-bis :to="`${$site.base}core-classes/kuzzle/constructor/`" />
+<Redirect to="core-classes/kuzzle/constructor/" />


### PR DESCRIPTION
## What does this PR do ?
Fix documentation redirect to first child by using the `<Redirect>` documentation framework component
