### PR TITLE
Replace ConcurrentHashMap by Map

### DIFF
--- a/.ci/doc/templates/catch.tpl.java
+++ b/.ci/doc/templates/catch.tpl.java
@@ -1,7 +1,7 @@
 import io.kuzzle.sdk.Kuzzle;
 import java.util.ArrayList;
 import io.kuzzle.sdk.protocol.WebSocket;
-import java.util.concurrent.ConcurrentHashMap;
+;
 import io.kuzzle.sdk.coreClasses.responses.Response;
 
 public class SnippetTest {

--- a/.ci/doc/templates/catch.tpl.java
+++ b/.ci/doc/templates/catch.tpl.java
@@ -2,6 +2,7 @@ import io.kuzzle.sdk.Kuzzle;
 import java.util.ArrayList;
 import io.kuzzle.sdk.protocol.WebSocket;
 import io.kuzzle.sdk.coreClasses.responses.Response;
+import java.util.*;
 
 public class SnippetTest {
   private static Kuzzle kuzzle;

--- a/.ci/doc/templates/catch.tpl.java
+++ b/.ci/doc/templates/catch.tpl.java
@@ -1,7 +1,6 @@
 import io.kuzzle.sdk.Kuzzle;
 import java.util.ArrayList;
 import io.kuzzle.sdk.protocol.WebSocket;
-;
 import io.kuzzle.sdk.coreClasses.responses.Response;
 
 public class SnippetTest {

--- a/.ci/doc/templates/catch.tpl.kt
+++ b/.ci/doc/templates/catch.tpl.kt
@@ -1,6 +1,6 @@
 import io.kuzzle.sdk.Kuzzle
 import io.kuzzle.sdk.protocol.WebSocket
-import java.util.concurrent.ConcurrentHashMap
+
 import java.util.concurrent.ExecutionException
 import io.kuzzle.sdk.coreClasses.responses.Response
 

--- a/.ci/doc/templates/default.tpl.java
+++ b/.ci/doc/templates/default.tpl.java
@@ -1,7 +1,6 @@
 import io.kuzzle.sdk.Kuzzle;
 import java.util.ArrayList;
 import io.kuzzle.sdk.protocol.WebSocket;
-;
 import io.kuzzle.sdk.coreClasses.responses.Response;
 import io.kuzzle.sdk.coreClasses.SearchResult;
 

--- a/.ci/doc/templates/default.tpl.java
+++ b/.ci/doc/templates/default.tpl.java
@@ -1,7 +1,7 @@
 import io.kuzzle.sdk.Kuzzle;
 import java.util.ArrayList;
 import io.kuzzle.sdk.protocol.WebSocket;
-import java.util.concurrent.ConcurrentHashMap;
+;
 import io.kuzzle.sdk.coreClasses.responses.Response;
 import io.kuzzle.sdk.coreClasses.SearchResult;
 

--- a/.ci/doc/templates/default.tpl.java
+++ b/.ci/doc/templates/default.tpl.java
@@ -1,8 +1,8 @@
 import io.kuzzle.sdk.Kuzzle;
-import java.util.ArrayList;
 import io.kuzzle.sdk.protocol.WebSocket;
 import io.kuzzle.sdk.coreClasses.responses.Response;
 import io.kuzzle.sdk.coreClasses.SearchResult;
+import java.util.*;
 
 public class SnippetTest {
   private static Kuzzle kuzzle;

--- a/.ci/doc/templates/default.tpl.kt
+++ b/.ci/doc/templates/default.tpl.kt
@@ -1,6 +1,6 @@
 import io.kuzzle.sdk.Kuzzle
 import io.kuzzle.sdk.protocol.WebSocket
-import java.util.concurrent.ConcurrentHashMap
+
 import java.util.concurrent.ExecutionException
 import io.kuzzle.sdk.coreClasses.responses.Response
 import io.kuzzle.sdk.coreClasses.SearchResult

--- a/.ci/doc/templates/print-result-array.tpl.java
+++ b/.ci/doc/templates/print-result-array.tpl.java
@@ -1,8 +1,6 @@
 import io.kuzzle.sdk.Kuzzle;
 import io.kuzzle.sdk.protocol.WebSocket;
 import io.kuzzle.sdk.coreClasses.responses.Response;
-
-;
 import java.util.ArrayList;
 
 public class SnippetTest {

--- a/.ci/doc/templates/print-result-array.tpl.java
+++ b/.ci/doc/templates/print-result-array.tpl.java
@@ -2,7 +2,7 @@ import io.kuzzle.sdk.Kuzzle;
 import io.kuzzle.sdk.protocol.WebSocket;
 import io.kuzzle.sdk.coreClasses.responses.Response;
 
-import java.util.concurrent.ConcurrentHashMap;
+;
 import java.util.ArrayList;
 
 public class SnippetTest {

--- a/.ci/doc/templates/print-result-array.tpl.java
+++ b/.ci/doc/templates/print-result-array.tpl.java
@@ -1,7 +1,7 @@
 import io.kuzzle.sdk.Kuzzle;
 import io.kuzzle.sdk.protocol.WebSocket;
 import io.kuzzle.sdk.coreClasses.responses.Response;
-import java.util.ArrayList;
+import java.util.*;
 
 public class SnippetTest {
   private static Kuzzle kuzzle;

--- a/.ci/doc/templates/print-result-array.tpl.kt
+++ b/.ci/doc/templates/print-result-array.tpl.kt
@@ -1,6 +1,6 @@
 import io.kuzzle.sdk.Kuzzle
 import io.kuzzle.sdk.protocol.WebSocket
-import java.util.concurrent.ConcurrentHashMap
+
 import java.util.concurrent.ExecutionException
 import io.kuzzle.sdk.coreClasses.responses.Response
 import io.kuzzle.sdk.coreClasses.maps.KuzzleMap

--- a/.ci/doc/templates/print-result-arraylist.tpl.java
+++ b/.ci/doc/templates/print-result-arraylist.tpl.java
@@ -1,8 +1,6 @@
 import io.kuzzle.sdk.Kuzzle;
 import io.kuzzle.sdk.protocol.WebSocket;
 import io.kuzzle.sdk.coreClasses.responses.Response;
-
-;
 import java.util.ArrayList;
 
 public class SnippetTest {

--- a/.ci/doc/templates/print-result-arraylist.tpl.java
+++ b/.ci/doc/templates/print-result-arraylist.tpl.java
@@ -2,7 +2,7 @@ import io.kuzzle.sdk.Kuzzle;
 import io.kuzzle.sdk.protocol.WebSocket;
 import io.kuzzle.sdk.coreClasses.responses.Response;
 
-import java.util.concurrent.ConcurrentHashMap;
+;
 import java.util.ArrayList;
 
 public class SnippetTest {

--- a/.ci/doc/templates/print-result-arraylist.tpl.java
+++ b/.ci/doc/templates/print-result-arraylist.tpl.java
@@ -1,7 +1,7 @@
 import io.kuzzle.sdk.Kuzzle;
 import io.kuzzle.sdk.protocol.WebSocket;
 import io.kuzzle.sdk.coreClasses.responses.Response;
-import java.util.ArrayList;
+import java.util.*;
 
 public class SnippetTest {
   private static Kuzzle kuzzle;

--- a/.ci/doc/templates/print-result-arraylist.tpl.kt
+++ b/.ci/doc/templates/print-result-arraylist.tpl.kt
@@ -1,6 +1,6 @@
 import io.kuzzle.sdk.Kuzzle
 import io.kuzzle.sdk.protocol.WebSocket
-import java.util.concurrent.ConcurrentHashMap
+
 import java.util.concurrent.ExecutionException
 import io.kuzzle.sdk.coreClasses.responses.Response
 

--- a/.ci/doc/templates/print-result.tpl.java
+++ b/.ci/doc/templates/print-result.tpl.java
@@ -3,7 +3,7 @@ import io.kuzzle.sdk.protocol.WebSocket;
 import java.util.Date;
 import io.kuzzle.sdk.coreClasses.responses.Response;
 
-import java.util.concurrent.ConcurrentHashMap;
+;
 import java.util.ArrayList;
 
 public class SnippetTest {

--- a/.ci/doc/templates/print-result.tpl.java
+++ b/.ci/doc/templates/print-result.tpl.java
@@ -2,8 +2,6 @@ import io.kuzzle.sdk.Kuzzle;
 import io.kuzzle.sdk.protocol.WebSocket;
 import java.util.Date;
 import io.kuzzle.sdk.coreClasses.responses.Response;
-
-;
 import java.util.ArrayList;
 
 public class SnippetTest {

--- a/.ci/doc/templates/print-result.tpl.java
+++ b/.ci/doc/templates/print-result.tpl.java
@@ -1,8 +1,7 @@
 import io.kuzzle.sdk.Kuzzle;
 import io.kuzzle.sdk.protocol.WebSocket;
-import java.util.Date;
 import io.kuzzle.sdk.coreClasses.responses.Response;
-import java.util.ArrayList;
+import java.util.*;
 
 public class SnippetTest {
   private static Kuzzle kuzzle;

--- a/.ci/doc/templates/print-result.tpl.kt
+++ b/.ci/doc/templates/print-result.tpl.kt
@@ -1,7 +1,7 @@
 import io.kuzzle.sdk.Kuzzle
 import io.kuzzle.sdk.protocol.WebSocket
 import java.util.Date
-import java.util.concurrent.ConcurrentHashMap
+
 import java.util.concurrent.ExecutionException
 import io.kuzzle.sdk.coreClasses.responses.Response
 

--- a/.ci/doc/templates/print-search-result.tpl.java
+++ b/.ci/doc/templates/print-search-result.tpl.java
@@ -1,7 +1,6 @@
 import io.kuzzle.sdk.Kuzzle;
 import java.util.ArrayList;
 import io.kuzzle.sdk.protocol.WebSocket;
-;
 import io.kuzzle.sdk.coreClasses.responses.Response;
 import io.kuzzle.sdk.coreClasses.SearchResult;
 

--- a/.ci/doc/templates/print-search-result.tpl.java
+++ b/.ci/doc/templates/print-search-result.tpl.java
@@ -1,7 +1,7 @@
 import io.kuzzle.sdk.Kuzzle;
 import java.util.ArrayList;
 import io.kuzzle.sdk.protocol.WebSocket;
-import java.util.concurrent.ConcurrentHashMap;
+;
 import io.kuzzle.sdk.coreClasses.responses.Response;
 import io.kuzzle.sdk.coreClasses.SearchResult;
 

--- a/.ci/doc/templates/print-search-result.tpl.java
+++ b/.ci/doc/templates/print-search-result.tpl.java
@@ -1,5 +1,5 @@
 import io.kuzzle.sdk.Kuzzle;
-import java.util.ArrayList;
+import java.util.*;
 import io.kuzzle.sdk.protocol.WebSocket;
 import io.kuzzle.sdk.coreClasses.responses.Response;
 import io.kuzzle.sdk.coreClasses.SearchResult;

--- a/.ci/doc/templates/print-search-result.tpl.kt
+++ b/.ci/doc/templates/print-search-result.tpl.kt
@@ -1,6 +1,6 @@
 import io.kuzzle.sdk.Kuzzle
 import io.kuzzle.sdk.protocol.WebSocket
-import java.util.concurrent.ConcurrentHashMap
+
 import java.util.concurrent.ExecutionException
 import io.kuzzle.sdk.coreClasses.responses.Response
 import io.kuzzle.sdk.coreClasses.SearchResult

--- a/.ci/doc/templates/without-connect.tpl.java
+++ b/.ci/doc/templates/without-connect.tpl.java
@@ -1,5 +1,6 @@
 import io.kuzzle.sdk.Kuzzle;
 import io.kuzzle.sdk.protocol.WebSocket;
+import java.util.*;
 
 public class SnippetTest {
   private static Kuzzle kuzzle;

--- a/.ci/doc/templates/without-connect.tpl.kt
+++ b/.ci/doc/templates/without-connect.tpl.kt
@@ -1,6 +1,6 @@
 import io.kuzzle.sdk.Kuzzle
 import io.kuzzle.sdk.protocol.WebSocket
-import java.util.concurrent.ConcurrentHashMap
+
 import java.util.concurrent.ExecutionException
 
 fun main() {

--- a/.ci/doc/templates/without-ctor.tpl.java
+++ b/.ci/doc/templates/without-ctor.tpl.java
@@ -1,5 +1,6 @@
 import io.kuzzle.sdk.Kuzzle;
 import io.kuzzle.sdk.protocol.WebSocket;
+import java.util.*;
 
 public class SnippetTest {
   public static void main(String[] argv) {

--- a/.ci/doc/templates/without-ctor.tpl.kt
+++ b/.ci/doc/templates/without-ctor.tpl.kt
@@ -1,6 +1,6 @@
 import io.kuzzle.sdk.Kuzzle
 import io.kuzzle.sdk.protocol.WebSocket
-import java.util.concurrent.ConcurrentHashMap
+
 import java.util.concurrent.ExecutionException
 
 fun main() {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 
 val artifactName = "sdk-jvm"
 val artifactGroup = "io.kuzzle"
-val artifactVersion = "1.0.2"
+val artifactVersion = "1.0.3-"
 
 val pomUrl = "https://github.com/kuzzleio/sdk-jvm"
 val pomScmUrl = "https://github.com/kuzzleio/sdk-jvm"

--- a/doc/1/controllers/auth/check-token/index.md
+++ b/doc/1/controllers/auth/check-token/index.md
@@ -15,7 +15,7 @@ Checks an authentication token's validity.
 ## Arguments
 
 ```java
-public CompletableFuture<ConcurrentHashMap<String, Object>> checkToken(String token)
+public CompletableFuture<Map<String, Object>> checkToken(String token)
   throws NotConnectedException, InternalException
 ```
 
@@ -25,7 +25,7 @@ public CompletableFuture<ConcurrentHashMap<String, Object>> checkToken(String to
 
 ## Return
 
-A ConcurrentHashMap which has the following properties:
+A Map which has the following properties:
 
 | Property     | Type              | Description                      |
 |--------------|-------------------|----------------------------------|
@@ -43,7 +43,7 @@ A ConcurrentHashMap which has the following properties:
 ## Arguments
 
 ```kotlin
-fun checkToken(token: String): CompletableFuture<ConcurrentHashMap<String, Any?>>
+fun checkToken(token: String): CompletableFuture<Map<String, Any?>>
 ```
 
 | Argument | Type              | Description |
@@ -52,7 +52,7 @@ fun checkToken(token: String): CompletableFuture<ConcurrentHashMap<String, Any?>
 
 ## Return
 
-A ConcurrentHashMap which has the following properties:
+A Map which has the following properties:
 
 | Property     | Type              | Description                      |
 |--------------|-------------------|----------------------------------|

--- a/doc/1/controllers/auth/check-token/snippets/check-token-java.java
+++ b/doc/1/controllers/auth/check-token/snippets/check-token-java.java
@@ -1,8 +1,8 @@
-ConcurrentHashMap<String, Object> credentials = new ConcurrentHashMap<>();
+Map<String, Object> credentials = new HashMap<>();
 credentials.put("username", "foo");
 credentials.put("password", "bar");
 
-ConcurrentHashMap<String, Object> response =
+Map<String, Object> response =
   kuzzle.getAuthController().login("local", credentials).get();
-ConcurrentHashMap<String, Object> responseToken =
+Map<String, Object> responseToken =
   kuzzle.getAuthController().checkToken(response.get("jwt").toString()).get();

--- a/doc/1/controllers/auth/check-token/snippets/check-token-kotlin.kt
+++ b/doc/1/controllers/auth/check-token/snippets/check-token-kotlin.kt
@@ -1,4 +1,4 @@
-val response = kuzzle.authController.login("local", Map<String, Any?>().apply {
+val response = kuzzle.authController.login("local", HashMap<String, Any?>().apply {
   put("username", "foo")
   put("password", "bar")
 }).get()

--- a/doc/1/controllers/auth/check-token/snippets/check-token-kotlin.kt
+++ b/doc/1/controllers/auth/check-token/snippets/check-token-kotlin.kt
@@ -1,7 +1,7 @@
-val response = kuzzle.authController.login("local", ConcurrentHashMap<String, Any?>().apply {
+val response = kuzzle.authController.login("local", Map<String, Any?>().apply {
   put("username", "foo")
   put("password", "bar")
 }).get()
 
-val responseToken: ConcurrentHashMap<String, Any?> =
+val responseToken: Map<String, Any?> =
   kuzzle.authController.checkToken(response["jwt"].toString()).get()

--- a/doc/1/controllers/auth/create-my-credentials/index.md
+++ b/doc/1/controllers/auth/create-my-credentials/index.md
@@ -15,19 +15,19 @@ Creates the current user's credentials for the specified strategy.
 ## Arguments
 
 ```java
-public CompletableFuture<ConcurrentHashMap<String, Object>> createMyCredentials(final String strategy,
-  final ConcurrentHashMap<String, Object> credentials)
+public CompletableFuture<Map<String, Object>> createMyCredentials(final String strategy,
+  final Map<String, Object> credentials)
   throws NotConnectedException, InternalException
 ```
 
 | Argument      | Type               | Description                          |
 |---------------|--------------------|--------------------------------------|
 | `strategy`    | <pre>String</pre>  | Strategy to use                      |
-| `credentials` | <pre>ConcurrentHashMap<String, Object></pre> | ConcurrentHashMap representing the credentials |
+| `credentials` | <pre>Map<String, Object></pre> | Map representing the credentials |
 
 ## Return
 
-A ConcurrentHashMap representing the new credentials.
+A Map representing the new credentials.
 
 ## Usage
 
@@ -41,17 +41,17 @@ A ConcurrentHashMap representing the new credentials.
 ```kotlin
 fun createMyCredentials(
       strategy: String,
-      credentials: ConcurrentHashMap<String, Any>): CompletableFuture<ConcurrentHashMap<String, Any?>>
+      credentials: Map<String, Any>): CompletableFuture<Map<String, Any?>>
 ```
 
 | Argument      | Type               | Description                          |
 |---------------|--------------------|--------------------------------------|
 | `strategy`    | <pre>String</pre>  | Strategy to use                      |
-| `credentials` | <pre>ConcurrentHashMap<String, Any?></pre> | ConcurrentHashMap representing the credentials |
+| `credentials` | <pre>Map<String, Any?></pre> | Map representing the credentials |
 
 ## Return
 
-A ConcurrentHashMap representing the new credentials.
+A Map representing the new credentials.
 
 ## Usage
 

--- a/doc/1/controllers/auth/create-my-credentials/snippets/create-my-credentials-java.java
+++ b/doc/1/controllers/auth/create-my-credentials/snippets/create-my-credentials-java.java
@@ -1,11 +1,11 @@
-ConcurrentHashMap<String, Object> credentials = new ConcurrentHashMap<>();
+Map<String, Object> credentials = new HashMap<>();
 credentials.put("username", "foo");
 credentials.put("password", "bar");
 
-ConcurrentHashMap<String, Object> newCredentials = new ConcurrentHashMap<>();
+Map<String, Object> newCredentials = new HashMap<>();
 newCredentials.put("username", "foo2");
 newCredentials.put("password", "bar2");
 
-ConcurrentHashMap<String, Object> response = 
+Map<String, Object> response =
   kuzzle.getAuthController().login("local", credentials).get();
 kuzzle.getAuthController().createMyCredentials("other", newCredentials).get();

--- a/doc/1/controllers/auth/create-my-credentials/snippets/create-my-credentials-kotlin.kt
+++ b/doc/1/controllers/auth/create-my-credentials/snippets/create-my-credentials-kotlin.kt
@@ -1,9 +1,9 @@
-kuzzle.authController.login("local", ConcurrentHashMap<String, Any?>().apply {
+kuzzle.authController.login("local", Map<String, Any?>().apply {
   put("username", "foo")
   put("password", "bar")
 }).get()
 
-kuzzle.authController.createMyCredentials("other", ConcurrentHashMap<String, Any?>().apply {
+kuzzle.authController.createMyCredentials("other", Map<String, Any?>().apply {
   put("username", "foo2")
   put("password", "bar2")
 }).get()

--- a/doc/1/controllers/auth/create-my-credentials/snippets/create-my-credentials-kotlin.kt
+++ b/doc/1/controllers/auth/create-my-credentials/snippets/create-my-credentials-kotlin.kt
@@ -1,9 +1,9 @@
-kuzzle.authController.login("local", Map<String, Any?>().apply {
+kuzzle.authController.login("local", HashMap<String, Any?>().apply {
   put("username", "foo")
   put("password", "bar")
 }).get()
 
-kuzzle.authController.createMyCredentials("other", Map<String, Any?>().apply {
+kuzzle.authController.createMyCredentials("other", HashMap<String, Any?>().apply {
   put("username", "foo2")
   put("password", "bar2")
 }).get()

--- a/doc/1/controllers/auth/credentials-exist/snippets/credentials-exist-java.java
+++ b/doc/1/controllers/auth/credentials-exist/snippets/credentials-exist-java.java
@@ -1,4 +1,4 @@
-ConcurrentHashMap<String, Object> credentials = new ConcurrentHashMap<>();
+Map<String, Object> credentials = new HashMap<>();
 credentials.put("username", "foo");
 credentials.put("password", "bar");
 

--- a/doc/1/controllers/auth/credentials-exist/snippets/credentials-exist-kotlin.kt
+++ b/doc/1/controllers/auth/credentials-exist/snippets/credentials-exist-kotlin.kt
@@ -1,4 +1,4 @@
-kuzzle.authController.login("local", ConcurrentHashMap<String, Any?>().apply {
+kuzzle.authController.login("local", Map<String, Any?>().apply {
   put("username", "foo")
   put("password", "bar")
 }).get()

--- a/doc/1/controllers/auth/credentials-exist/snippets/credentials-exist-kotlin.kt
+++ b/doc/1/controllers/auth/credentials-exist/snippets/credentials-exist-kotlin.kt
@@ -1,4 +1,4 @@
-kuzzle.authController.login("local", Map<String, Any?>().apply {
+kuzzle.authController.login("local", HashMap<String, Any?>().apply {
   put("username", "foo")
   put("password", "bar")
 }).get()

--- a/doc/1/controllers/auth/delete-my-credentials/snippets/delete-my-credentials-java.java
+++ b/doc/1/controllers/auth/delete-my-credentials/snippets/delete-my-credentials-java.java
@@ -1,6 +1,6 @@
-ConcurrentHashMap<String, Object> credentials = new ConcurrentHashMap<>();
+Map<String, Object> credentials = new HashMap<>();
 credentials.put("username", "foo");
 credentials.put("password", "bar");
 
-ConcurrentHashMap<String, Object> response = kuzzle.getAuthController().login("local", credentials).get();
+Map<String, Object> response = kuzzle.getAuthController().login("local", credentials).get();
 kuzzle.getAuthController().deleteMyCredentials("local").get();

--- a/doc/1/controllers/auth/delete-my-credentials/snippets/delete-my-credentials-kotlin.kt
+++ b/doc/1/controllers/auth/delete-my-credentials/snippets/delete-my-credentials-kotlin.kt
@@ -1,4 +1,4 @@
-kuzzle.authController.login("local", ConcurrentHashMap<String, Any?>().apply {
+kuzzle.authController.login("local", Map<String, Any?>().apply {
   put("username", "foo")
   put("password", "bar")
 }).get()

--- a/doc/1/controllers/auth/delete-my-credentials/snippets/delete-my-credentials-kotlin.kt
+++ b/doc/1/controllers/auth/delete-my-credentials/snippets/delete-my-credentials-kotlin.kt
@@ -1,4 +1,4 @@
-kuzzle.authController.login("local", Map<String, Any?>().apply {
+kuzzle.authController.login("local", HashMap<String, Any?>().apply {
   put("username", "foo")
   put("password", "bar")
 }).get()

--- a/doc/1/controllers/auth/get-current-user/index.md
+++ b/doc/1/controllers/auth/get-current-user/index.md
@@ -15,19 +15,19 @@ Returns informations about the user currently loggued with the SDK instance.
 ## Arguments
 
 ```java
-public CompletableFuture<ConcurrentHashMap<String, Object>> getCurrentUser()
+public CompletableFuture<Map<String, Object>> getCurrentUser()
   throws NotConnectedException, InternalException
 ```
 
 ## Return
 
-A ConcurrentHashMap representing the User.
+A Map representing the User.
 
 | Property     | Type               | Description                                       |
 |--------------|--------------------|---------------------------------------------------|
 | `_id`        | <pre>String</pre>  | Representing the current user `kuid`              |
 | `strategies` | <pre>Array</pre>  | Available authentication strategies for that user |
-| `_source`    | <pre>ConcurrentHashMap</pre> | User information                                  |
+| `_source`    | <pre>Map</pre> | User information                                  |
 
 ## Usage
 
@@ -39,18 +39,18 @@ A ConcurrentHashMap representing the User.
 ## Arguments
 
 ```kotlin
-fun getCurrentUser(): CompletableFuture<ConcurrentHashMap<String, Any?>>
+fun getCurrentUser(): CompletableFuture<Map<String, Any?>>
 ```
 
 ## Return
 
-A ConcurrentHashMap representing the User.
+A Map representing the User.
 
 | Property     | Type               | Description                                       |
 |--------------|--------------------|---------------------------------------------------|
 | `_id`        | <pre>String</pre>  | Representing the current user `kuid`              |
 | `strategies` | <pre>Array</pre>  | Available authentication strategies for that user |
-| `_source`    | <pre>ConcurrentHashMap</pre> | User information                                  |
+| `_source`    | <pre>Map</pre> | User information                                  |
 
 ## Usage
 

--- a/doc/1/controllers/auth/get-current-user/snippets/get-current-user-java.java
+++ b/doc/1/controllers/auth/get-current-user/snippets/get-current-user-java.java
@@ -1,6 +1,6 @@
-ConcurrentHashMap<String, Object> credentials = new ConcurrentHashMap<>();
+Map<String, Object> credentials = new HashMap<>();
 credentials.put("username", "foo");
 credentials.put("password", "bar");
 
 kuzzle.getAuthController().login("local", credentials).get();
-ConcurrentHashMap<String, Object> result = kuzzle.getAuthController().getCurrentUser().get();
+Map<String, Object> result = kuzzle.getAuthController().getCurrentUser().get();

--- a/doc/1/controllers/auth/get-current-user/snippets/get-current-user-kotlin.kt
+++ b/doc/1/controllers/auth/get-current-user/snippets/get-current-user-kotlin.kt
@@ -1,7 +1,7 @@
-kuzzle.authController.login("local", ConcurrentHashMap<String, Any?>().apply {
+kuzzle.authController.login("local", Map<String, Any?>().apply {
   put("username", "foo")
   put("password", "bar")
 }).get()
 
-val result: ConcurrentHashMap<String, Any?> =
+val result: Map<String, Any?> =
   kuzzle.authController.getCurrentUser().get()

--- a/doc/1/controllers/auth/get-current-user/snippets/get-current-user-kotlin.kt
+++ b/doc/1/controllers/auth/get-current-user/snippets/get-current-user-kotlin.kt
@@ -1,4 +1,4 @@
-kuzzle.authController.login("local", Map<String, Any?>().apply {
+kuzzle.authController.login("local", HashMap<String, Any?>().apply {
   put("username", "foo")
   put("password", "bar")
 }).get()

--- a/doc/1/controllers/auth/get-my-credentials/index.md
+++ b/doc/1/controllers/auth/get-my-credentials/index.md
@@ -15,7 +15,7 @@ Returns the current user's credential information for the specified strategy. Th
 ## Arguments
 
 ```java
-public CompletableFuture<ConcurrentHashMap<String, Object>> getMyCredentials(String strategy)
+public CompletableFuture<Map<String, Object>> getMyCredentials(String strategy)
   throws NotConnectedException, InternalException
 ```
 
@@ -25,7 +25,7 @@ public CompletableFuture<ConcurrentHashMap<String, Object>> getMyCredentials(Str
 
 ## Return
 
-Returns a ConcurrentHashMap representing the credentials for the provided authentication strategy.
+Returns a Map representing the credentials for the provided authentication strategy.
 
 ## Usage
 
@@ -38,7 +38,7 @@ Returns a ConcurrentHashMap representing the credentials for the provided authen
 
 ```kotlin
 fun getMyCredentials(
-      strategy: String): CompletableFuture<ConcurrentHashMap<String, Any?>>
+      strategy: String): CompletableFuture<Map<String, Any?>>
 ```
 
 | Argument   | Type              | Description     |
@@ -47,7 +47,7 @@ fun getMyCredentials(
 
 ## Return
 
-Returns a ConcurrentHashMap representing the credentials for the provided authentication strategy.
+Returns a Map representing the credentials for the provided authentication strategy.
 
 ## Usage
 

--- a/doc/1/controllers/auth/get-my-credentials/snippets/get-my-credentials-java.java
+++ b/doc/1/controllers/auth/get-my-credentials/snippets/get-my-credentials-java.java
@@ -1,7 +1,7 @@
-ConcurrentHashMap<String, Object> credentials = new ConcurrentHashMap<>();
+Map<String, Object> credentials = new HashMap<>();
 credentials.put("username", "foo");
 credentials.put("password", "bar");
 
 kuzzle.getAuthController().login("local", credentials).get();
-ConcurrentHashMap<String, Object> result = 
+Map<String, Object> result =
   kuzzle.getAuthController().getMyCredentials("local").get();

--- a/doc/1/controllers/auth/get-my-credentials/snippets/get-my-credentials-kotlin.kt
+++ b/doc/1/controllers/auth/get-my-credentials/snippets/get-my-credentials-kotlin.kt
@@ -1,7 +1,7 @@
-kuzzle.authController.login("local", ConcurrentHashMap<String, Any?>().apply {
+kuzzle.authController.login("local", Map<String, Any?>().apply {
   put("username", "foo")
   put("password", "bar")
 }).get()
 
-val result: ConcurrentHashMap<String, Any?> =
+val result: Map<String, Any?> =
   kuzzle.authController.getMyCredentials("local").get()

--- a/doc/1/controllers/auth/get-my-credentials/snippets/get-my-credentials-kotlin.kt
+++ b/doc/1/controllers/auth/get-my-credentials/snippets/get-my-credentials-kotlin.kt
@@ -1,4 +1,4 @@
-kuzzle.authController.login("local", Map<String, Any?>().apply {
+kuzzle.authController.login("local", HashMap<String, Any?>().apply {
   put("username", "foo")
   put("password", "bar")
 }).get()

--- a/doc/1/controllers/auth/get-my-rights/snippets/get-my-rights-java.java
+++ b/doc/1/controllers/auth/get-my-rights/snippets/get-my-rights-java.java
@@ -1,4 +1,4 @@
-ConcurrentHashMap<String, Object> credentials = new ConcurrentHashMap<>();
+Map<String, Object> credentials = new HashMap<>();
 credentials.put("username", "foo");
 credentials.put("password", "bar");
 

--- a/doc/1/controllers/auth/get-my-rights/snippets/get-my-rights-kotlin.kt
+++ b/doc/1/controllers/auth/get-my-rights/snippets/get-my-rights-kotlin.kt
@@ -1,4 +1,4 @@
-kuzzle.authController.login("local", ConcurrentHashMap<String, Any?>().apply {
+kuzzle.authController.login("local", Map<String, Any?>().apply {
   put("username", "foo")
   put("password", "bar")
 }).get()

--- a/doc/1/controllers/auth/get-my-rights/snippets/get-my-rights-kotlin.kt
+++ b/doc/1/controllers/auth/get-my-rights/snippets/get-my-rights-kotlin.kt
@@ -1,4 +1,4 @@
-kuzzle.authController.login("local", Map<String, Any?>().apply {
+kuzzle.authController.login("local", HashMap<String, Any?>().apply {
   put("username", "foo")
   put("password", "bar")
 }).get()

--- a/doc/1/controllers/auth/get-strategies/snippets/get-strategies-java.java
+++ b/doc/1/controllers/auth/get-strategies/snippets/get-strategies-java.java
@@ -1,4 +1,4 @@
-ConcurrentHashMap<String, Object> credentials = new ConcurrentHashMap<>();
+Map<String, Object> credentials = new HashMap<>();
 credentials.put("username", "foo");
 credentials.put("password", "bar");
 

--- a/doc/1/controllers/auth/get-strategies/snippets/get-strategies-kotlin.kt
+++ b/doc/1/controllers/auth/get-strategies/snippets/get-strategies-kotlin.kt
@@ -1,4 +1,4 @@
-kuzzle.authController.login("local", ConcurrentHashMap<String, Any?>().apply {
+kuzzle.authController.login("local", Map<String, Any?>().apply {
   put("username", "foo")
   put("password", "bar")
 }).get()

--- a/doc/1/controllers/auth/get-strategies/snippets/get-strategies-kotlin.kt
+++ b/doc/1/controllers/auth/get-strategies/snippets/get-strategies-kotlin.kt
@@ -1,4 +1,4 @@
-kuzzle.authController.login("local", Map<String, Any?>().apply {
+kuzzle.authController.login("local", HashMap<String, Any?>().apply {
   put("username", "foo")
   put("password", "bar")
 }).get()

--- a/doc/1/controllers/auth/login/index.md
+++ b/doc/1/controllers/auth/login/index.md
@@ -17,15 +17,15 @@ If this action is successful, all further requests emitted by this SDK instance 
 ## Arguments
 
 ```java
-CompletableFuture<ConcurrentHashMap<String, Object>> login(
+CompletableFuture<Map<String, Object>> login(
   final String strategy,
-  final ConcurrentHashMap<String, Object> credentials,
+  final Map<String, Object> credentials,
   final String expiresIn) 
   throws NotConnectedException, InternalException
 
-CompletableFuture<ConcurrentHashMap<String, Object>> login(
+CompletableFuture<Map<String, Object>> login(
   final String strategy,
-  final ConcurrentHashMap<String, Object> credentials) 
+  final Map<String, Object> credentials) 
   throws NotConnectedException, InternalException
 ```
 
@@ -34,7 +34,7 @@ CompletableFuture<ConcurrentHashMap<String, Object>> login(
 | Argument      | Type                 | Description                          |
 |---------------|----------------------|--------------------------------------|
 | `strategy`    | <pre>String</pre>    | Strategy to use                      |
-| `credentials` | <pre>ConcurrentHashMap<String, Object></pre>   | Hashmap representing the credentials |
+| `credentials` | <pre>Map<String, Object></pre>   | Hashmap representing the credentials |
 | `expiresIn`   | <pre>String</pre> | Token duration                       |
 
 #### strategy
@@ -77,8 +77,8 @@ Once `auth:login` has been called, the returned authentication token is stored b
 ```kotlin
 fun login(
   strategy: String,
-  credentials: ConcurrentHashMap<String, Any?>?,
-  expiresIn: String? = null): CompletableFuture<ConcurrentHashMap<String, Any?>>
+  credentials: Map<String, Any?>?,
+  expiresIn: String? = null): CompletableFuture<Map<String, Any?>>
 ```
 
 <br/>
@@ -86,7 +86,7 @@ fun login(
 | Argument      | Type                 | Description                          |
 |---------------|----------------------|--------------------------------------|
 | `strategy`    | <pre>String</pre>    | Strategy to use                      |
-| `credentials` | <pre>ConcurrentHashMap<String, Any?></pre>   | Hashmap representing the credentials |
+| `credentials` | <pre>Map<String, Any?></pre>   | Hashmap representing the credentials |
 | `expiresIn`   | <pre>String?</pre> | Token duration                       |
 
 #### strategy

--- a/doc/1/controllers/auth/login/snippets/login-java.java
+++ b/doc/1/controllers/auth/login/snippets/login-java.java
@@ -1,6 +1,6 @@
-ConcurrentHashMap<String, Object> credentials = new ConcurrentHashMap<>();
+Map<String, Object> credentials = new HashMap<>();
   credentials.put("username", "foo");
   credentials.put("password", "bar");
 
-ConcurrentHashMap<String, Object> result = 
+Map<String, Object> result =
   kuzzle.getAuthController().login("local", credentials).get();

--- a/doc/1/controllers/auth/login/snippets/login-kotlin.kt
+++ b/doc/1/controllers/auth/login/snippets/login-kotlin.kt
@@ -1,5 +1,5 @@
 val result: Map<String, Any?> =
-    kuzzle.authController.login("local", Map<String, Any?>().apply {
+    kuzzle.authController.login("local", HashMap<String, Any?>().apply {
       put("username", "foo")
       put("password", "bar")
     }).get()

--- a/doc/1/controllers/auth/login/snippets/login-kotlin.kt
+++ b/doc/1/controllers/auth/login/snippets/login-kotlin.kt
@@ -1,5 +1,5 @@
-val result: ConcurrentHashMap<String, Any?> =
-    kuzzle.authController.login("local", ConcurrentHashMap<String, Any?>().apply {
+val result: Map<String, Any?> =
+    kuzzle.authController.login("local", Map<String, Any?>().apply {
       put("username", "foo")
       put("password", "bar")
     }).get()

--- a/doc/1/controllers/auth/logout/snippets/logout-java.java
+++ b/doc/1/controllers/auth/logout/snippets/logout-java.java
@@ -1,4 +1,4 @@
-ConcurrentHashMap<String, Object> credentials = new ConcurrentHashMap<>();
+Map<String, Object> credentials = new HashMap<>();
 credentials.put("username", "foo");
 credentials.put("password", "bar");
 

--- a/doc/1/controllers/auth/logout/snippets/logout-kotlin.kt
+++ b/doc/1/controllers/auth/logout/snippets/logout-kotlin.kt
@@ -1,4 +1,4 @@
-kuzzle.authController.login("local", ConcurrentHashMap<String, Any?>().apply {
+kuzzle.authController.login("local", Map<String, Any?>().apply {
   put("username", "foo")
   put("password", "bar")
 }).get()

--- a/doc/1/controllers/auth/logout/snippets/logout-kotlin.kt
+++ b/doc/1/controllers/auth/logout/snippets/logout-kotlin.kt
@@ -1,4 +1,4 @@
-kuzzle.authController.login("local", Map<String, Any?>().apply {
+kuzzle.authController.login("local", HashMap<String, Any?>().apply {
   put("username", "foo")
   put("password", "bar")
 }).get()

--- a/doc/1/controllers/auth/refresh-token/index.md
+++ b/doc/1/controllers/auth/refresh-token/index.md
@@ -19,10 +19,10 @@ Refreshes an authentication token.
 ## Arguments
 
 ```java
-CompletableFuture<ConcurrentHashMap<String, Object>> refreshToken(
+CompletableFuture<Map<String, Object>> refreshToken(
   String expiresIn) throws NotConnectedException, InternalException
 
-CompletableFuture<ConcurrentHashMap<String, Object>> refreshToken()
+CompletableFuture<Map<String, Object>> refreshToken()
   throws NotConnectedException, InternalException
 ```
 
@@ -34,7 +34,7 @@ CompletableFuture<ConcurrentHashMap<String, Object>> refreshToken()
 
 ## Return
 
-A ConcurrentHashMap with the following properties:
+A Map with the following properties:
 
 | Property    | Type              | Description                                                                              |
 |-------------|-------------------|------------------------------------------------------------------------------------------|
@@ -55,7 +55,7 @@ Once `auth:refreshToken` has been called, the returned authentication token is s
 
 ```kotlin
 fun refreshToken(
-      expiresIn: String? = null): CompletableFuture<ConcurrentHashMap<String, Any?>>
+      expiresIn: String? = null): CompletableFuture<Map<String, Any?>>
 ```
 
 **Optional:**
@@ -66,7 +66,7 @@ fun refreshToken(
 
 ## Return
 
-A ConcurrentHashMap with the following properties:
+A Map with the following properties:
 
 | Property    | Type              | Description                                                                              |
 |-------------|-------------------|------------------------------------------------------------------------------------------|

--- a/doc/1/controllers/auth/refresh-token/snippets/refresh-token-java.java
+++ b/doc/1/controllers/auth/refresh-token/snippets/refresh-token-java.java
@@ -1,7 +1,7 @@
-ConcurrentHashMap<String, Object> credentials = new ConcurrentHashMap<>();
+Map<String, Object> credentials = new HashMap<>();
 credentials.put("username", "foo");
 credentials.put("password", "bar");
 
 kuzzle.getAuthController().login("local", credentials).get();
-ConcurrentHashMap<String, Object> result = 
+Map<String, Object> result =
   kuzzle.getAuthController().refreshToken("1h").get();

--- a/doc/1/controllers/auth/refresh-token/snippets/refresh-token-kotlin.kt
+++ b/doc/1/controllers/auth/refresh-token/snippets/refresh-token-kotlin.kt
@@ -1,7 +1,7 @@
-kuzzle.authController.login("local", ConcurrentHashMap<String, Any?>().apply {
+kuzzle.authController.login("local", Map<String, Any?>().apply {
   put("username", "foo")
   put("password", "bar")
 }).get()
 
-val result: ConcurrentHashMap<String, Any?> =
+val result: Map<String, Any?> =
   kuzzle.authController.refreshToken("1h").get();

--- a/doc/1/controllers/auth/refresh-token/snippets/refresh-token-kotlin.kt
+++ b/doc/1/controllers/auth/refresh-token/snippets/refresh-token-kotlin.kt
@@ -1,4 +1,4 @@
-kuzzle.authController.login("local", Map<String, Any?>().apply {
+kuzzle.authController.login("local", HashMap<String, Any?>().apply {
   put("username", "foo")
   put("password", "bar")
 }).get()

--- a/doc/1/controllers/auth/update-my-credentials/index.md
+++ b/doc/1/controllers/auth/update-my-credentials/index.md
@@ -15,20 +15,20 @@ Updates the current user's credentials for the specified strategy. The credentia
 ## Arguments
 
 ```java
-CompletableFuture<ConcurrentHashMap<String, Object>> updateMyCredentials(
+CompletableFuture<Map<String, Object>> updateMyCredentials(
   String strategy,
-  ConcurrentHashMap<String, Object> credentials)
+  Map<String, Object> credentials)
   throws NotConnectedException, InternalException
 ```
 
 | Argument      | Type               | Description                          |
 |---------------|--------------------|--------------------------------------|
 | `strategy`    | <pre>String</pre>  | Strategy to use                      |
-| `credentials` | <pre>ConcurrentHashMap<String, Object></pre> | JObject representing the credentials |
+| `credentials` | <pre>Map<String, Object></pre> | JObject representing the credentials |
 
 ## Return
 
-A ConcurrentHashMap representing the updated credentials with the following properties:
+A Map representing the updated credentials with the following properties:
 
 | Property   | Type              | Description       |
 |------------|-------------------|-------------------|
@@ -46,17 +46,17 @@ A ConcurrentHashMap representing the updated credentials with the following prop
 ```kotlin
 fun updateMyCredentials(
       strategy: String,
-      credentials: ConcurrentHashMap<String, Any?>): CompletableFuture<ConcurrentHashMap<String, Any?>>
+      credentials: Map<String, Any?>): CompletableFuture<Map<String, Any?>>
 ```
 
 | Argument      | Type               | Description                          |
 |---------------|--------------------|--------------------------------------|
 | `strategy`    | <pre>String</pre>  | Strategy to use                      |
-| `credentials` | <pre>ConcurrentHashMap<String, Any?></pre> | JObject representing the credentials |
+| `credentials` | <pre>Map<String, Any?></pre> | JObject representing the credentials |
 
 ## Return
 
-A ConcurrentHashMap representing the updated credentials with the following properties:
+A Map representing the updated credentials with the following properties:
 
 | Property   | Type              | Description       |
 |------------|-------------------|-------------------|

--- a/doc/1/controllers/auth/update-my-credentials/snippets/update-my-credentials-java.java
+++ b/doc/1/controllers/auth/update-my-credentials/snippets/update-my-credentials-java.java
@@ -1,6 +1,6 @@
-ConcurrentHashMap<String, Object> credentials = new ConcurrentHashMap<>();
+Map<String, Object> credentials = new HashMap<>();
 credentials.put("username", "foo");
 credentials.put("password", "bar");
 
 kuzzle.getAuthController().login("local", credentials).get();
-ConcurrentHashMap<String, Object> result = kuzzle.getAuthController().updateMyCredentials("local", credentials).get();
+Map<String, Object> result = kuzzle.getAuthController().updateMyCredentials("local", credentials).get();

--- a/doc/1/controllers/auth/update-my-credentials/snippets/update-my-credentials-kotlin.kt
+++ b/doc/1/controllers/auth/update-my-credentials/snippets/update-my-credentials-kotlin.kt
@@ -1,9 +1,9 @@
-val credentials = ConcurrentHashMap<String, Any?>().apply {
+val credentials = Map<String, Any?>().apply {
   put("username", "foo")
   put("password", "bar")
 }
 
 kuzzle.authController.login("local", credentials).get()
 
-val result: ConcurrentHashMap<String, Any?> =
+val result: Map<String, Any?> =
   kuzzle.authController.updateMyCredentials("local", credentials).get();

--- a/doc/1/controllers/auth/update-my-credentials/snippets/update-my-credentials-kotlin.kt
+++ b/doc/1/controllers/auth/update-my-credentials/snippets/update-my-credentials-kotlin.kt
@@ -1,4 +1,4 @@
-val credentials = Map<String, Any?>().apply {
+val credentials = HashMap<String, Any?>().apply {
   put("username", "foo")
   put("password", "bar")
 }

--- a/doc/1/controllers/auth/update-self/index.md
+++ b/doc/1/controllers/auth/update-self/index.md
@@ -15,23 +15,23 @@ Updates the current user object in Kuzzle.
 ## Arguments
 
 ```java
-CompletableFuture<ConcurrentHashMap<String, Object>> updateSelf(
-  final ConcurrentHashMap<String, Object> content)
+CompletableFuture<Map<String, Object>> updateSelf(
+  final Map<String, Object> content)
   throws NotConnectedException, InternalException
 ```
 
 | Argument  | Type               | Description                           |
 |-----------|--------------------|---------------------------------------|
-| `content` | <pre>ConcurrentHashMap<String, Object></pre> | Hashmap representing the user content |
+| `content` | <pre>Map<String, Object></pre> | Hashmap representing the user content |
 
 ## Return
 
-Returns a ConcurrentHashMap with the following properties:
+Returns a Map with the following properties:
 
 | Property  | Type               | Description                               |
 |-----------|--------------------|-------------------------------------------|
 | `_id`     | <pre>String</pre>  | User's `kuid`                             |
-| `_source` | <pre>ConcurrentHashMap<String, Object></pre> | Additional (and optional) user properties |
+| `_source` | <pre>Map<String, Object></pre> | Additional (and optional) user properties |
 
 ## Usage
 
@@ -44,21 +44,21 @@ Returns a ConcurrentHashMap with the following properties:
 
 ```kotlin
 fun updateSelf(
-      content: ConcurrentHashMap<String, Any?>): CompletableFuture<ConcurrentHashMap<String, Any?>>
+      content: Map<String, Any?>): CompletableFuture<Map<String, Any?>>
 ```
 
 | Argument  | Type               | Description                           |
 |-----------|--------------------|---------------------------------------|
-| `content` | <pre>ConcurrentHashMap<String, Any?></pre> | Hashmap representing the user content |
+| `content` | <pre>Map<String, Any?></pre> | Hashmap representing the user content |
 
 ## Return
 
-Returns a ConcurrentHashMap with the following properties:
+Returns a Map with the following properties:
 
 | Property  | Type               | Description                               |
 |-----------|--------------------|-------------------------------------------|
 | `_id`     | <pre>String</pre>  | User's `kuid`                             |
-| `_source` | <pre>ConcurrentHashMap<String, Any?></pre> | Additional (and optional) user properties |
+| `_source` | <pre>Map<String, Any?></pre> | Additional (and optional) user properties |
 
 ## Usage
 

--- a/doc/1/controllers/auth/update-self/snippets/update-self-java.java
+++ b/doc/1/controllers/auth/update-self/snippets/update-self-java.java
@@ -1,11 +1,11 @@
-ConcurrentHashMap<String, Object> credentials = new ConcurrentHashMap<>();
+Map<String, Object> credentials = new HashMap<>();
 credentials.put("username", "foo");
 credentials.put("password", "bar");
 
 kuzzle.getAuthController().login("local", credentials).get();
 
-ConcurrentHashMap<String, Object> custom = new ConcurrentHashMap<>();
+Map<String, Object> custom = new HashMap<>();
 custom.put("age", 42);
 
-ConcurrentHashMap<String, Object> result = 
+Map<String, Object> result =
   kuzzle.getAuthController().updateSelf(custom).get();

--- a/doc/1/controllers/auth/update-self/snippets/update-self-kotlin.kt
+++ b/doc/1/controllers/auth/update-self/snippets/update-self-kotlin.kt
@@ -1,9 +1,9 @@
-kuzzle.authController.login("local", ConcurrentHashMap<String, Any?>().apply {
+kuzzle.authController.login("local", Map<String, Any?>().apply {
   put("username", "foo")
   put("password", "bar")
 }).get()
 
-val result: ConcurrentHashMap<String, Any?> =
-  kuzzle.authController.updateSelf(ConcurrentHashMap<String, Any?>().apply {
+val result: Map<String, Any?> =
+  kuzzle.authController.updateSelf(Map<String, Any?>().apply {
     put("age", 42)
   }).get();

--- a/doc/1/controllers/auth/update-self/snippets/update-self-kotlin.kt
+++ b/doc/1/controllers/auth/update-self/snippets/update-self-kotlin.kt
@@ -1,9 +1,9 @@
-kuzzle.authController.login("local", Map<String, Any?>().apply {
+kuzzle.authController.login("local", HashMap<String, Any?>().apply {
   put("username", "foo")
   put("password", "bar")
 }).get()
 
 val result: Map<String, Any?> =
-  kuzzle.authController.updateSelf(Map<String, Any?>().apply {
+  kuzzle.authController.updateSelf(HashMap<String, Any?>().apply {
     put("age", 42)
   }).get();

--- a/doc/1/controllers/auth/validate-my-credentials/index.md
+++ b/doc/1/controllers/auth/validate-my-credentials/index.md
@@ -16,14 +16,14 @@ Validates the current user's credentials for the specified strategy. This method
 
 ```java
 CompletableFuture<Boolean> validateMyCredentials(final String strategy,
-  final ConcurrentHashMap<String, Object> credentials)
+  final Map<String, Object> credentials)
   throws NotConnectedException, InternalException
 ```
 
 | Argument      | Type               | Description                          |
 |---------------|--------------------|--------------------------------------|
 | `strategy`    | <pre>String</pre>  | Strategy to use                      |
-| `credentials` | <pre>ConcurrentHashMap<String, Object></pre> | A Hashmap representing the credentials |
+| `credentials` | <pre>Map<String, Object></pre> | A Hashmap representing the credentials |
 
 ## Return
 
@@ -40,13 +40,13 @@ A Boolean indicating if the credentials are valid.
 
 ```kotlin
 fun validateMyCredentials(strategy: String,
-  credentials: ConcurrentHashMap<String, Any?>): CompletableFuture<Boolean>
+  credentials: Map<String, Any?>): CompletableFuture<Boolean>
 ```
 
 | Argument      | Type               | Description                          |
 |---------------|--------------------|--------------------------------------|
 | `strategy`    | <pre>String</pre>  | Strategy to use                      |
-| `credentials` | <pre>ConcurrentHashMap<String, Any?></pre> | A Hashmap representing the credentials |
+| `credentials` | <pre>Map<String, Any?></pre> | A Hashmap representing the credentials |
 
 ## Return
 

--- a/doc/1/controllers/auth/validate-my-credentials/snippets/validate-my-credentials-java.java
+++ b/doc/1/controllers/auth/validate-my-credentials/snippets/validate-my-credentials-java.java
@@ -1,4 +1,4 @@
-ConcurrentHashMap<String, Object> credentials = new ConcurrentHashMap<>();
+Map<String, Object> credentials = new HashMap<>();
 credentials.put("username", "foo");
 credentials.put("password", "bar");
 

--- a/doc/1/controllers/auth/validate-my-credentials/snippets/validate-my-credentials-kotlin.kt
+++ b/doc/1/controllers/auth/validate-my-credentials/snippets/validate-my-credentials-kotlin.kt
@@ -1,4 +1,4 @@
-val credentials = ConcurrentHashMap<String, Any?>().apply {
+val credentials = Map<String, Any?>().apply {
   put("username", "foo")
   put("password", "bar")
 }

--- a/doc/1/controllers/auth/validate-my-credentials/snippets/validate-my-credentials-kotlin.kt
+++ b/doc/1/controllers/auth/validate-my-credentials/snippets/validate-my-credentials-kotlin.kt
@@ -1,4 +1,4 @@
-val credentials = Map<String, Any?>().apply {
+val credentials = HashMap<String, Any?>().apply {
   put("username", "foo")
   put("password", "bar")
 }

--- a/doc/1/controllers/bulk/delete-by-query/index.md
+++ b/doc/1/controllers/bulk/delete-by-query/index.md
@@ -20,14 +20,14 @@ Kuzzle uses the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasti
 public CompletableFuture<Int> deleteByQuery(
   String index,
   String collection,
-  ConcurrentHashMap<String, Object> searchQuery,
+  Map<String, Object> searchQuery,
   Boolean waitForRefresh
 ) throws NotConnectedException, InternalException
 
 public CompletableFuture<Int> deleteByQuery(
   String index,
   String collection,
-  ConcurrentHashMap<String, Object> searchQuery
+  Map<String, Object> searchQuery
 ) throws NotConnectedException, InternalException
 ```
 
@@ -37,7 +37,7 @@ public CompletableFuture<Int> deleteByQuery(
 | ------------ | ------------------------------------ | --------------------------------------- |
 | `index`      | <pre>String</pre>        | Index name                              |
 | `collection` | <pre>String</pre>        | Collection name                         |
-| `searchQuery`      | <pre>ConcurrentHashMap<String, Any?></pre>        | JSON representing the query to match |
+| `searchQuery`      | <pre>Map<String, Any?></pre>        | JSON representing the query to match |
 | `waitForRefresh` | <pre>Bool</pre><br>(`false`)  | If set to true, Kuzzle will not respond until the delete documents are indexed |
 
 
@@ -58,7 +58,7 @@ An Int containing the number of deleted documents.
 fun deleteByQuery(
   index: String,
   collection: String,
-  searchQuery: ConcurrentHashMap<String, Any?>,
+  searchQuery: Map<String, Any?>,
   waitForRefresh: Boolean? = null
 ): CompletableFuture<Int>
 ```
@@ -69,7 +69,7 @@ fun deleteByQuery(
 | ------------ | ------------------------------------ | --------------------------------------- |
 | `index`      | <pre>String</pre>        | Index name                              |
 | `collection` | <pre>String</pre>        | Collection name                         |
-| `searchQuery`      | <pre>ConcurrentHashMap<String, Any?></pre>        | JSON representing the query to match |
+| `searchQuery`      | <pre>Map<String, Any?></pre>        | JSON representing the query to match |
 | `waitForRefresh` | <pre>Boolean</pre><br>(`false`)  | If set to true, Kuzzle will not respond until the delete documents are indexed |
 
 

--- a/doc/1/controllers/bulk/delete-by-query/snippets/delete-by-query-java.java
+++ b/doc/1/controllers/bulk/delete-by-query/snippets/delete-by-query-java.java
@@ -1,7 +1,7 @@
-ConcurrentHashMap<String, Object> term = new ConcurrentHashMap<String, Object>();
+Map<String, Object> term = new HashMap<String, Object>();
 term.put("capacity", 7);
 
-ConcurrentHashMap<String, Object> searchQuery = new ConcurrentHashMap<String, Object>();
+Map<String, Object> searchQuery = new HashMap<String, Object>();
 searchQuery.put("query", term);
 
 Integer result = kuzzle.getBulkController().deleteByQuery("nyc-open-data", "yellow-taxi", searchQuery).get();

--- a/doc/1/controllers/bulk/delete-by-query/snippets/delete-by-query-kotlin.kt
+++ b/doc/1/controllers/bulk/delete-by-query/snippets/delete-by-query-kotlin.kt
@@ -1,6 +1,6 @@
-val searchQuery: ConcurrentHashMap<String, Any?> = ConcurrentHashMap<String, Any?>().apply {
-  put("query", ConcurrentHashMap<String, Any?>().apply {
-    put("term", ConcurrentHashMap<String, Any?>().apply {
+val searchQuery: Map<String, Any?> = Map<String, Any?>().apply {
+  put("query", Map<String, Any?>().apply {
+    put("term", Map<String, Any?>().apply {
       put("capacity", 7)
     })
   })

--- a/doc/1/controllers/bulk/delete-by-query/snippets/delete-by-query-kotlin.kt
+++ b/doc/1/controllers/bulk/delete-by-query/snippets/delete-by-query-kotlin.kt
@@ -1,6 +1,6 @@
-val searchQuery: Map<String, Any?> = Map<String, Any?>().apply {
-  put("query", Map<String, Any?>().apply {
-    put("term", Map<String, Any?>().apply {
+val searchQuery: Map<String, Any?> = HashMap<String, Any?>().apply {
+  put("query", HashMap<String, Any?>().apply {
+    put("term", HashMap<String, Any?>().apply {
       put("capacity", 7)
     })
   })

--- a/doc/1/controllers/bulk/import-data/index.md
+++ b/doc/1/controllers/bulk/import-data/index.md
@@ -17,10 +17,10 @@ This route is faster than the `document:m*` routes family (e.g. [document:mCreat
 ## Arguments
 
 ```java
-public CompletableFuture<ConcurrentHashMap<String, Object>> importData(
+public CompletableFuture<Map<String, Object>> importData(
     String index,
     String collection,
-    ArrayList<ConcurrentHashMap<String, Object>> bulkData
+    ArrayList<Map<String, Object>> bulkData
 ) throws NotConnectedException, InternalException
 ```
 
@@ -28,7 +28,7 @@ public CompletableFuture<ConcurrentHashMap<String, Object>> importData(
 |--------------|-------------------|--------------------------------------------------------------|
 | `index`      | <pre>String</pre> | Index name                                                   |
 | `collection` | <pre>String</pre> | Collection name                                              |
-| `bulkData`   | <pre>ArrayList<ConcurrentHashMap<String, Object>></pre> | Bulk operations to perform, following ElasticSearch Bulk API |
+| `bulkData`   | <pre>ArrayList<Map<String, Object>></pre> | Bulk operations to perform, following ElasticSearch Bulk API |
 
 ### bulkData
 
@@ -55,12 +55,12 @@ Learn more at [Elasticsearch Bulk API](https://www.elastic.co/guide/en/elasticse
 
 ## Return
 
-A ConcurrentHashMap<String, Any?> containing 2 arrays:
+A Map<String, Any?> containing 2 arrays:
 
 | Property | Type                | Description                                         |
 | -------- | ------------------- | --------------------------------------------------- |
-| `successes`  | <pre>ArrayList<ConcurrentHashMap<String, Object>></pre> | Array of object containing successful document import |
-| `errors` | <pre>ArrayList<ConcurrentHashMap<String, Object>></pre>  | Array of object containing failed document import     |
+| `successes`  | <pre>ArrayList<Map<String, Object>></pre> | Array of object containing successful document import |
+| `errors` | <pre>ArrayList<Map<String, Object>></pre>  | Array of object containing failed document import     |
 
 Each item of the `successes` array is an object containing the action name as key and the corresponding object contain the following properties:
 
@@ -75,7 +75,7 @@ Each item of the `errors` array is an object containing the action name as key a
 | -------- | ------------------- | --------------------------------------------------- |
 | `_id`   | <pre>String</pre>   | Document unique identifier      |
 | `status`   | <pre>Integer</pre>   | HTTP status code for that query      |
-| `error`   | <pre><ConcurrentHashMap<String, Object></pre>   | Error object      |
+| `error`   | <pre><Map<String, Object></pre>   | Error object      |
 
 Each `error` object contain the following properties:
 
@@ -97,15 +97,15 @@ Each `error` object contain the following properties:
 fun importData(
   index: String,
   collection: String,
-  bulkData: ArrayList<ConcurrentHashMap<String, Any?>>
-  ): CompletableFuture<ConcurrentHashMap<String, Any?>>
+  bulkData: ArrayList<Map<String, Any?>>
+  ): CompletableFuture<Map<String, Any?>>
 ```
 
 | Argument     | Type              | Description                                                  |
 |--------------|-------------------|--------------------------------------------------------------|
 | `index`      | <pre>String</pre> | Index name                                                   |
 | `collection` | <pre>String</pre> | Collection name                                              |
-| `bulkData`   | <pre>ArrayList<ConcurrentHashMap<String, Any?>></pre> | Bulk operations to perform, following ElasticSearch Bulk API |
+| `bulkData`   | <pre>ArrayList<Map<String, Any?>></pre> | Bulk operations to perform, following ElasticSearch Bulk API |
 
 ### bulkData
 
@@ -132,12 +132,12 @@ Learn more at [Elasticsearch Bulk API](https://www.elastic.co/guide/en/elasticse
 
 ## Return
 
-A ConcurrentHashMap<String, Any?> containing 2 arrays:
+A Map<String, Any?> containing 2 arrays:
 
 | Property | Type                | Description                                         |
 | -------- | ------------------- | --------------------------------------------------- |
-| `successes`  | <pre>ArrayList<ConcurrentHashMap<String, Any?>></pre> | Array of object containing successful document import |
-| `errors` | <pre>ArrayList<ConcurrentHashMap<String, Any?>></pre>  | Array of object containing failed document import     |
+| `successes`  | <pre>ArrayList<Map<String, Any?>></pre> | Array of object containing successful document import |
+| `errors` | <pre>ArrayList<Map<String, Any?>></pre>  | Array of object containing failed document import     |
 
 Each item of the `successes` array is an object containing the action name as key and the corresponding object contain the following properties:
 
@@ -152,7 +152,7 @@ Each item of the `errors` array is an object containing the action name as key a
 | -------- | ------------------- | --------------------------------------------------- |
 | `_id`   | <pre>String</pre>   | Document unique identifier      |
 | `status`   | <pre>Int</pre>   | HTTP status code for that query      |
-| `error`   | <pre><ConcurrentHashMap<String, Any?></pre>   | Error object      |
+| `error`   | <pre><Map<String, Any?></pre>   | Error object      |
 
 Each `error` object contain the following properties:
 

--- a/doc/1/controllers/bulk/import-data/snippets/import-data-java.java
+++ b/doc/1/controllers/bulk/import-data/snippets/import-data-java.java
@@ -1,31 +1,31 @@
 
-ConcurrentHashMap<String, Object> index = new ConcurrentHashMap<String, Object>();
-index.put("index", new ConcurrentHashMap<String, Object>());
+Map<String, Object> index = new HashMap<String, Object>();
+index.put("index", new HashMap<String, Object>());
 
-ConcurrentHashMap<String, Object> document = new ConcurrentHashMap<String, Object>();
+Map<String, Object> document = new HashMap<String, Object>();
 document.put("a", "document");
 document.put("with", "any");
 document.put("number", "of fields");
 
-ConcurrentHashMap<String, Object> id = new ConcurrentHashMap<String, Object>();
+Map<String, Object> id = new HashMap<String, Object>();
 id.put("_id", "uniq-id-1");
-ConcurrentHashMap<String, Object> create = new ConcurrentHashMap<String, Object>();
+Map<String, Object> create = new HashMap<String, Object>();
 create.put("create", id);
 
-ConcurrentHashMap<String, Object> document2 = new ConcurrentHashMap<String, Object>();
+Map<String, Object> document2 = new HashMap<String, Object>();
 document2.put("another", "document");
 
-ConcurrentHashMap<String, Object> id2 = new ConcurrentHashMap<String, Object>();
+Map<String, Object> id2 = new HashMap<String, Object>();
 id2.put("_id", "uniq-id-2");
-ConcurrentHashMap<String, Object> create2 = new ConcurrentHashMap<String, Object>();
+Map<String, Object> create2 = new HashMap<String, Object>();
 create2.put("create", id2);
 
-ConcurrentHashMap<String, Object> another = new ConcurrentHashMap<String, Object>();
+Map<String, Object> another = new HashMap<String, Object>();
 id2.put("another", "one");
-ConcurrentHashMap<String, Object> and = new ConcurrentHashMap<String, Object>();
+Map<String, Object> and = new HashMap<String, Object>();
 create2.put("and", another);
 
-ArrayList<ConcurrentHashMap<String, Object>> bulkData = new ArrayList<ConcurrentHashMap<String, Object>>();
+ArrayList<Map<String, Object>> bulkData = new ArrayList<Map<String, Object>>();
 bulkData.add(index);
 bulkData.add(document);
 bulkData.add(create);
@@ -33,7 +33,7 @@ bulkData.add(document2);
 bulkData.add(create2);
 bulkData.add(and);
 
-ConcurrentHashMap<String, Object> result =
+Map<String, Object> result =
   kuzzle.getBulkController().importData(
     "nyc-open-data",
     "yellow-taxi",

--- a/doc/1/controllers/bulk/import-data/snippets/import-data-kotlin.kt
+++ b/doc/1/controllers/bulk/import-data/snippets/import-data-kotlin.kt
@@ -1,6 +1,6 @@
 val bulkData: ArrayList<Map<String, Any?>> = ArrayList<Map<String, Any?>>().apply {
   add(HashMap<String, Any?>().apply {
-    put("index", Map<String, Any?>());
+    put("index", HashMap<String, Any?>());
   });
   add(HashMap<String, Any?>().apply {
     put("a", "document");

--- a/doc/1/controllers/bulk/import-data/snippets/import-data-kotlin.kt
+++ b/doc/1/controllers/bulk/import-data/snippets/import-data-kotlin.kt
@@ -1,39 +1,39 @@
-val bulkData: ArrayList<ConcurrentHashMap<String, Any?>> = ArrayList<ConcurrentHashMap<String, Any?>>().apply {
-  add(ConcurrentHashMap<String, Any?>().apply {
-    put("index", ConcurrentHashMap<String, Any?>());
+val bulkData: ArrayList<Map<String, Any?>> = ArrayList<Map<String, Any?>>().apply {
+  add(Map<String, Any?>().apply {
+    put("index", Map<String, Any?>());
   });
-  add(ConcurrentHashMap<String, Any?>().apply {
+  add(Map<String, Any?>().apply {
     put("a", "document");
     put("with", "any");
     put("number", "of fields");
   });
-  add(ConcurrentHashMap<String, Any?>().apply {
+  add(Map<String, Any?>().apply {
     put("create", 
-      ConcurrentHashMap<String, Any?>().apply {
+      Map<String, Any?>().apply {
         put("_id", "uniq-id-1");
       }
     );
   });
-  add(ConcurrentHashMap<String, Any?>().apply {
+  add(Map<String, Any?>().apply {
     put("another", "document");
   });
-  add(ConcurrentHashMap<String, Any?>().apply {
+  add(Map<String, Any?>().apply {
     put("create", 
-      ConcurrentHashMap<String, Any?>().apply {
+      Map<String, Any?>().apply {
         put("_id", "uniq-id-2");
       }
     );
   });
-  add(ConcurrentHashMap<String, Any?>().apply {
+  add(Map<String, Any?>().apply {
     put("and", 
-      ConcurrentHashMap<String, Any?>().apply {
+      Map<String, Any?>().apply {
         put("another", "one");
       }
     );
   });
 };
 
-val result: ConcurrentHashMap<String, Any?> =
+val result: Map<String, Any?> =
   kuzzle.bulkController.importData(
     "nyc-open-data",
     "yellow-taxi",

--- a/doc/1/controllers/bulk/import-data/snippets/import-data-kotlin.kt
+++ b/doc/1/controllers/bulk/import-data/snippets/import-data-kotlin.kt
@@ -1,32 +1,32 @@
 val bulkData: ArrayList<Map<String, Any?>> = ArrayList<Map<String, Any?>>().apply {
-  add(Map<String, Any?>().apply {
+  add(HashMap<String, Any?>().apply {
     put("index", Map<String, Any?>());
   });
-  add(Map<String, Any?>().apply {
+  add(HashMap<String, Any?>().apply {
     put("a", "document");
     put("with", "any");
     put("number", "of fields");
   });
-  add(Map<String, Any?>().apply {
+  add(HashMap<String, Any?>().apply {
     put("create", 
-      Map<String, Any?>().apply {
+      HashMap<String, Any?>().apply {
         put("_id", "uniq-id-1");
       }
     );
   });
-  add(Map<String, Any?>().apply {
+  add(HashMap<String, Any?>().apply {
     put("another", "document");
   });
-  add(Map<String, Any?>().apply {
+  add(HashMap<String, Any?>().apply {
     put("create", 
-      Map<String, Any?>().apply {
+      HashMap<String, Any?>().apply {
         put("_id", "uniq-id-2");
       }
     );
   });
-  add(Map<String, Any?>().apply {
+  add(HashMap<String, Any?>().apply {
     put("and", 
-      Map<String, Any?>().apply {
+      HashMap<String, Any?>().apply {
         put("another", "one");
       }
     );

--- a/doc/1/controllers/bulk/m-write/index.md
+++ b/doc/1/controllers/bulk/m-write/index.md
@@ -18,10 +18,10 @@ This is a low level route intended to bypass Kuzzle actions on document creation
 ## Arguments
 
 ```java
-public CompletableFuture<ConcurrentHashMap<String, Object>> importData (
+public CompletableFuture<Map<String, Object>> importData (
   String index,
   String collection,
-  ArrayList<ConcurrentHashMap<String, Object>> bulkData
+  ArrayList<Map<String, Object>> bulkData
 ) throws NotConnectedException, InternalException
 ```
 
@@ -29,11 +29,11 @@ public CompletableFuture<ConcurrentHashMap<String, Object>> importData (
 |--------------|-------------------|----------------------------------------------------------------------------------------------------------------------------------|
 | `index`      | <pre>String</pre> | Index name                                                                                                                       |
 | `collection` | <pre>String</pre> | Collection name                                                                                                                  |
-| `documents`  | <pre>ArrayList<ConcurrentHashMap<String, Object>></pre> | An array of JObject representing the documents|
+| `documents`  | <pre>ArrayList<Map<String, Object>></pre> | An array of JObject representing the documents|
 
 ### documents
 
-An array of `ConcurrentHashMap<String, Object>`. Each object describes a document to create or replace, by exposing the following properties:
+An array of `Map<String, Object>`. Each object describes a document to create or replace, by exposing the following properties:
   - `_id`: document unique identifier (optional)
   - `body`: document content
 
@@ -46,7 +46,7 @@ An array of `ConcurrentHashMap<String, Object>`. Each object describes a documen
 
 ## Return
 
-Returns a `ConcurrentHashMap<String, Object>` containing 2 arrays: `successes` and `errors`
+Returns a `Map<String, Object>` containing 2 arrays: `successes` and `errors`
 
 Each created or replaced document is an object of the `successes` array with the following properties:
 
@@ -54,14 +54,14 @@ Each created or replaced document is an object of the `successes` array with the
 | --------- | ----------------- | ------------------------------------------------------ |
 | `_id`      | <pre>String</pre> | Document ID                     |
 | `_version` | <pre>Integer</pre> | Version of the document in the persistent data storage |
-| `_source`  | <pre>ConcurrentHashMap<String, Object></pre> | Document content                                       |
+| `_source`  | <pre>Map<String, Object></pre> | Document content                                       |
 | `created`  | <pre>Bool</pre> | True if the document was created |
 
 Each errored document is an object of the `errors` array with the following properties:
 
 | Name      | Type              | Description                                            |
 | --------- | ----------------- | ------------------------------------------------------ |
-| `document`  | <pre>ConcurrentHashMap<String, Object></pre> | Document that cause the error                                       |
+| `document`  | <pre>Map<String, Object></pre> | Document that cause the error                                       |
 | `status` | <pre>Integer</pre> | HTTP error status |
 | `reason`  | <pre>String</pre> | Human readable reason |
 
@@ -78,19 +78,19 @@ Each errored document is an object of the `errors` array with the following prop
 fun importData(
   index: String,
   collection: String,
-  bulkData: ArrayList<ConcurrentHashMap<String, Any?>>
-): CompletableFuture<ConcurrentHashMap<String, Any?>>
+  bulkData: ArrayList<Map<String, Any?>>
+): CompletableFuture<Map<String, Any?>>
 ```
 
 | Argument     | Type              | Description                                                                                                                      |
 |--------------|-------------------|----------------------------------------------------------------------------------------------------------------------------------|
 | `index`      | <pre>String</pre> | Index name                                                                                                                       |
 | `collection` | <pre>String</pre> | Collection name                                                                                                                  |
-| `documents`  | <pre>ArrayList<ConcurrentHashMap<String, Any?>></pre> | An array of JObject representing the documents|
+| `documents`  | <pre>ArrayList<Map<String, Any?>></pre> | An array of JObject representing the documents|
 
 ### documents
 
-An array of `ConcurrentHashMap<String, Any?>`. Each object describes a document to create or replace, by exposing the following properties:
+An array of `Map<String, Any?>`. Each object describes a document to create or replace, by exposing the following properties:
   - `_id`: document unique identifier (optional)
   - `body`: document content
 
@@ -103,7 +103,7 @@ An array of `ConcurrentHashMap<String, Any?>`. Each object describes a document 
 
 ## Return
 
-Returns a `ConcurrentHashMap<String, Object>` containing 2 arrays: `successes` and `errors`
+Returns a `Map<String, Object>` containing 2 arrays: `successes` and `errors`
 
 Each created or replaced document is an object of the `successes` array with the following properties:
 
@@ -111,14 +111,14 @@ Each created or replaced document is an object of the `successes` array with the
 | --------- | ----------------- | ------------------------------------------------------ |
 | `_id`      | <pre>String</pre> | Document ID                     |
 | `_version` | <pre>Int</pre> | Version of the document in the persistent data storage |
-| `_source`  | <pre><ConcurrentHashMap<String, Any?></pre> | Document content                                       |
+| `_source`  | <pre><Map<String, Any?></pre> | Document content                                       |
 | `created`  | <pre>Bool</pre> | True if the document was created |
 
 Each errored document is an object of the `errors` array with the following properties:
 
 | Name      | Type              | Description                                            |
 | --------- | ----------------- | ------------------------------------------------------ |
-| `document`  | <pre>ConcurrentHashMap<String, Any?></pre> | Document that cause the error                                       |
+| `document`  | <pre>Map<String, Any?></pre> | Document that cause the error                                       |
 | `status` | <pre>Int</pre> | HTTP error status |
 | `reason`  | <pre>String</pre> | Human readable reason |
 

--- a/doc/1/controllers/bulk/m-write/snippets/mwrite-java.java
+++ b/doc/1/controllers/bulk/m-write/snippets/mwrite-java.java
@@ -1,8 +1,8 @@
-ConcurrentHashMap<String, Object> document = new ConcurrentHashMap<String, Object>();
-ArrayList<ConcurrentHashMap<String, Object>> documents = new ArrayList<ConcurrentHashMap<String, Object>>();
+Map<String, Object> document = new HashMap<String, Object>();
+ArrayList<Map<String, Object>> documents = new ArrayList<Map<String, Object>>();
 documents.add(document);
 document.put("_id", "foo");
-document.put("body", new ConcurrentHashMap<String, Object>());
+document.put("body", new HashMap<String, Object>());
 
-ConcurrentHashMap<String, Object> result = 
+Map<String, Object> result =
 kuzzle.getBulkController().mWrite("nyc-open-data", "yellow-taxi", documents).get();

--- a/doc/1/controllers/bulk/m-write/snippets/mwrite-kotlin.kt
+++ b/doc/1/controllers/bulk/m-write/snippets/mwrite-kotlin.kt
@@ -1,7 +1,7 @@
 val documents: ArrayList<Map<String, Any?>> = ArrayList<Map<String, Any?>>().apply {
   add(HashMap<String, Any?>().apply {
     put("_id", "foo")
-    put("body", Map<String, Any?>())
+    put("body", HashMap<String, Any?>())
   })
 };
 

--- a/doc/1/controllers/bulk/m-write/snippets/mwrite-kotlin.kt
+++ b/doc/1/controllers/bulk/m-write/snippets/mwrite-kotlin.kt
@@ -1,9 +1,9 @@
-val documents: ArrayList<ConcurrentHashMap<String, Any?>> = ArrayList<ConcurrentHashMap<String, Any?>>().apply {
-  add(ConcurrentHashMap<String, Any?>().apply {
+val documents: ArrayList<Map<String, Any?>> = ArrayList<Map<String, Any?>>().apply {
+  add(Map<String, Any?>().apply {
     put("_id", "foo")
-    put("body", ConcurrentHashMap<String, Any?>())
+    put("body", Map<String, Any?>())
   })
 };
 
-val result: ConcurrentHashMap<String, Any?> = 
+val result: Map<String, Any?> = 
 kuzzle.bulkController.mWrite("nyc-open-data", "yellow-taxi", documents).get();

--- a/doc/1/controllers/bulk/m-write/snippets/mwrite-kotlin.kt
+++ b/doc/1/controllers/bulk/m-write/snippets/mwrite-kotlin.kt
@@ -1,5 +1,5 @@
 val documents: ArrayList<Map<String, Any?>> = ArrayList<Map<String, Any?>>().apply {
-  add(Map<String, Any?>().apply {
+  add(HashMap<String, Any?>().apply {
     put("_id", "foo")
     put("body", Map<String, Any?>())
   })

--- a/doc/1/controllers/bulk/write/index.md
+++ b/doc/1/controllers/bulk/write/index.md
@@ -15,34 +15,34 @@ Create or replace a document directly into the storage engine.
 ## Arguments
 
 ```java
-public CompletableFuture<ConcurrentHashMap<String, Object>> write(
+public CompletableFuture<Map<String, Object>> write(
   String index,
   String collection,
-  ConcurrentHashMap<String, Object> content,
+  Map<String, Object> content,
   String id,
   Bool notify,
   Bool waitForRefresh
 ) throws NotConnectedException, InternalException
 
-public CompletableFuture<ConcurrentHashMap<String, Object>> write(
+public CompletableFuture<Map<String, Object>> write(
   String index,
   String collection,
-  ConcurrentHashMap<String, Object> content,
+  Map<String, Object> content,
   String id,
   Bool notify
 ) throws NotConnectedException, InternalException
 
-public CompletableFuture<ConcurrentHashMap<String, Object>> write(
+public CompletableFuture<Map<String, Object>> write(
   String index,
   String collection,
-  ConcurrentHashMap<String, Object> content,
+  Map<String, Object> content,
   String id
 ) throws NotConnectedException, InternalException
 
-public CompletableFuture<ConcurrentHashMap<String, Object>> write(
+public CompletableFuture<Map<String, Object>> write(
   String index,
   String collection,
-  ConcurrentHashMap<String, Object> content
+  Map<String, Object> content
 ) throws NotConnectedException, InternalException
 ```
 
@@ -50,19 +50,19 @@ public CompletableFuture<ConcurrentHashMap<String, Object>> write(
 |--------------|--------------------|-----------------------------|
 | `index`      | <pre>String</pre>  | Index name                  |
 | `collection` | <pre>String</pre>  | Collection name             |
-| `content`    | <pre>ConcurrentHashMap<String, Object></pre> | Document content to create. |
+| `content`    | <pre>Map<String, Object></pre> | Document content to create. |
 | `id`         | <pre>String</pre><br>(`null`) | set the document unique ID to the provided value, instead of auto-generating a random ID |
 | `waitForRefresh` | <pre>Bool</pre><br>(`false`)  | If set to true, Kuzzle will not respond until the created/replaced documents are indexed |
 | `notify`         | <pre>Bool</pre><br>(`false`)  | If set to true, Kuzzle will trigger realtime notifications                               |
 
 ## Return
 
-Return a ConcurrentHashMap<String, Object> with the following properties:
+Return a Map<String, Object> with the following properties:
 
 | Property   | Type               | Description                                     |
 |------------|--------------------|-------------------------------------------------|
 | `_id`      | <pre>String</pre>  | Created document unique identifier.             |
-| `_source`  | <pre>ConcurrentHashMap<String, Object></pre> | Document content.                               |
+| `_source`  | <pre>Map<String, Object></pre> | Document content.                               |
 | `_version` | <pre>Int</pre>     | Version number of the document                  |
 
 ## Usage
@@ -78,18 +78,18 @@ Return a ConcurrentHashMap<String, Object> with the following properties:
 fun write(
   index: String,
   collection: String,
-  content: ConcurrentHashMap<String, Any?>,
+  content: Map<String, Any?>,
   id: String? = null,
   notify: Boolean? = null,
   waitForRefresh: Boolean? = null):
-  CompletableFuture<ConcurrentHashMap<String, Any?>>
+  CompletableFuture<Map<String, Any?>>
 ```
 
 | Argument     | Type               | Description                 |
 |--------------|--------------------|-----------------------------|
 | `index`      | <pre>String</pre>  | Index name                  |
 | `collection` | <pre>String</pre>  | Collection name             |
-| `content`    | <pre>ConcurrentHashMap<String, Any?></pre> | Document content to create. |
+| `content`    | <pre>Map<String, Any?></pre> | Document content to create. |
 
 
 ### Options
@@ -102,12 +102,12 @@ fun write(
 
 ## Return
 
-Return a ConcurrentHashMap<Strin, Any?> with the following properties:
+Return a Map<Strin, Any?> with the following properties:
 
 | Property   | Type               | Description                                     |
 |------------|--------------------|-------------------------------------------------|
 | `_id`      | <pre>String</pre>  | Created document unique identifier.             |
-| `_source`  | <pre>ConcurrentHashMap<String, Any?></pre> | Document content.                               |
+| `_source`  | <pre>Map<String, Any?></pre> | Document content.                               |
 | `_version` | <pre>Int</pre>     | Version number of the document                  |
 
 ## Usage

--- a/doc/1/controllers/bulk/write/snippets/write-java.java
+++ b/doc/1/controllers/bulk/write/snippets/write-java.java
@@ -1,9 +1,9 @@
-ConcurrentHashMap<String, Object> content = new ConcurrentHashMap<String, Object>();
-ConcurrentHashMap<String, Object> kuzzleInfo = new ConcurrentHashMap<String, Object>();
+Map<String, Object> content = new HashMap<String, Object>();
+Map<String, Object> kuzzleInfo = new HashMap<String, Object>();
 kuzzleInfo.put("author", "<kuid>");
 kuzzleInfo.put("createdAd", "1481816934209");
 
 content.put("_kuzzle_info", kuzzleInfo);
 
-ConcurrentHashMap<String, Object> result = 
+Map<String, Object> result =
 kuzzle.getBulkController().write("nyc-open-data", "yellow-taxi", content).get();

--- a/doc/1/controllers/bulk/write/snippets/write-kotlin.kt
+++ b/doc/1/controllers/bulk/write/snippets/write-kotlin.kt
@@ -1,9 +1,9 @@
-val content: ConcurrentHashMap<String, Any?> = ConcurrentHashMap<String, Any?>().apply {
-  put("_kuzzle_info", ConcurrentHashMap<String, Any?>().apply {
+val content: Map<String, Any?> = Map<String, Any?>().apply {
+  put("_kuzzle_info", Map<String, Any?>().apply {
     put("author", "<kuid>")
     put("createdAd", "1481816934209")
   });
 }
 
-val result: ConcurrentHashMap<String, Any?> = 
+val result: Map<String, Any?> =
 kuzzle.bulkController.write("nyc-open-data", "yellow-taxi", content).get();

--- a/doc/1/controllers/bulk/write/snippets/write-kotlin.kt
+++ b/doc/1/controllers/bulk/write/snippets/write-kotlin.kt
@@ -1,5 +1,5 @@
-val content: Map<String, Any?> = Map<String, Any?>().apply {
-  put("_kuzzle_info", Map<String, Any?>().apply {
+val content: Map<String, Any?> = HashMap<String, Any?>().apply {
+  put("_kuzzle_info", HashMap<String, Any?>().apply {
     put("author", "<kuid>")
     put("createdAd", "1481816934209")
   });

--- a/doc/1/controllers/collection/create/index.md
+++ b/doc/1/controllers/collection/create/index.md
@@ -25,7 +25,7 @@ This method will only update the mappings and/or the settings if the collection 
 public CompletableFuture<Void> create(
       final String index,
       final String collection,
-      final ConcurrentHashMap<String, Object> definition)
+      final Map<String, Object> definition)
 throws NotConnectedException, InternalException
 
 public CompletableFuture<Void> create(
@@ -38,7 +38,7 @@ throws NotConnectedException, InternalException
 | ------------------ | -------------------------------------------- | --------------------------------- |
 | `index`            | <pre>String</pre>                            | Index                             |
 | `collection`       | <pre>String</pre>                            | Collection                        |
-| `definition`          | <pre>ConcurrentHashMap<String, Object></pre> | Describes the collection mappings and the ES index settings |
+| `definition`          | <pre>Map<String, Object></pre> | Describes the collection mappings and the ES index settings |
 
 ---
 
@@ -80,14 +80,14 @@ The mappings must have a root field `properties` that contain the mapping defini
 fun create(
       index: String,
       collection: String,
-      definition: ConcurrentHashMap<String, Any>?
+      definition: Map<String, Any>?
     ): CompletableFuture<Void>
 ```
 | Arguments          | Type                                         | Description                       |
 | ------------------ | -------------------------------------------- | --------------------------------- |
 | `index`            | <pre>String</pre>                            | Index                             |
 | `collection`       | <pre>String</pre>                            | Collection                        |
-| `definition`       | <pre>ConcurrentHashMap<String, Any>?</pre>   | Describes the collection mappings and the ES index settings |
+| `definition`       | <pre>Map<String, Any>?</pre>   | Describes the collection mappings and the ES index settings |
 
 ---
 

--- a/doc/1/controllers/collection/create/snippets/create-java.java
+++ b/doc/1/controllers/collection/create/snippets/create-java.java
@@ -1,7 +1,7 @@
-ConcurrentHashMap<String, Object> definition = new ConcurrentHashMap<>();
-ConcurrentHashMap<String, Object> mappings = new ConcurrentHashMap<>();
-ConcurrentHashMap<String, Object> properties = new ConcurrentHashMap<>();
-ConcurrentHashMap<String, Object> license = new ConcurrentHashMap<>();
+Map<String, Object> definition = new HashMap<>();
+Map<String, Object> mappings = new HashMap<>();
+Map<String, Object> properties = new HashMap<>();
+Map<String, Object> license = new HashMap<>();
 
 license.put("type", "keyword");
 properties.put("license", license);

--- a/doc/1/controllers/collection/create/snippets/create-kotlin.kt
+++ b/doc/1/controllers/collection/create/snippets/create-kotlin.kt
@@ -1,13 +1,13 @@
-val type: Map<String, Any> = Map<String, Any>().apply {
+val type: Map<String, Any> = HashMap<String, Any>().apply {
   put("type", "keyword")
 }
-val license: Map<String, Any> = Map<String, Any>().apply {
+val license: Map<String, Any> = HashMap<String, Any>().apply {
   put("license", type)
 }
-val mappings: Map<String, Any> = Map<String, Any>().apply {
+val mappings: Map<String, Any> = HashMap<String, Any>().apply {
   put("properties", license)
 }
-val definition: Map<String, Any> = Map<String, Any>().apply {
+val definition: Map<String, Any> = HashMap<String, Any>().apply {
   put("mappings", mappings)
 }
 kuzzle.collectionController.create(

--- a/doc/1/controllers/collection/create/snippets/create-kotlin.kt
+++ b/doc/1/controllers/collection/create/snippets/create-kotlin.kt
@@ -1,13 +1,13 @@
-val type: ConcurrentHashMap<String, Any> = ConcurrentHashMap<String, Any>().apply {
+val type: Map<String, Any> = Map<String, Any>().apply {
   put("type", "keyword")
 }
-val license: ConcurrentHashMap<String, Any> = ConcurrentHashMap<String, Any>().apply {
+val license: Map<String, Any> = Map<String, Any>().apply {
   put("license", type)
 }
-val mappings: ConcurrentHashMap<String, Any> = ConcurrentHashMap<String, Any>().apply {
+val mappings: Map<String, Any> = Map<String, Any>().apply {
   put("properties", license)
 }
-val definition: ConcurrentHashMap<String, Any> = ConcurrentHashMap<String, Any>().apply {
+val definition: Map<String, Any> = Map<String, Any>().apply {
   put("mappings", mappings)
 }
 kuzzle.collectionController.create(

--- a/doc/1/controllers/collection/get-mapping/index.md
+++ b/doc/1/controllers/collection/get-mapping/index.md
@@ -17,7 +17,7 @@ Returns the collection mapping.
 ## Arguments
 
 ```java
-public CompletableFuture<ConcurrentHashMap<String, Object>> getMapping(
+public CompletableFuture<Map<String, Object>> getMapping(
       final String index,
       final String collection) throws NotConnectedException, InternalException
 ```
@@ -31,7 +31,7 @@ public CompletableFuture<ConcurrentHashMap<String, Object>> getMapping(
 
 ## Returns
 
-Returns a `ConcurrentHashMap<String, Object>` representing the collection mappings.
+Returns a `Map<String, Object>` representing the collection mappings.
 
 ## Usage
 
@@ -46,7 +46,7 @@ Returns a `ConcurrentHashMap<String, Object>` representing the collection mappin
 fun getMapping(
     index: String,
     collection: String
-  ): CompletableFuture<ConcurrentHashMap<String, Any?>>
+  ): CompletableFuture<Map<String, Any?>>
 ```
 
 | Arguments    | Type              | Description     |
@@ -57,7 +57,7 @@ fun getMapping(
 
 ## Returns
 
-Returns a `ConcurrentHashMap<String, Any?>` representing the collection mappings.
+Returns a `Map<String, Any?>` representing the collection mappings.
 
 ## Usage
 

--- a/doc/1/controllers/collection/get-mapping/snippets/get-mapping-java.java
+++ b/doc/1/controllers/collection/get-mapping/snippets/get-mapping-java.java
@@ -1,4 +1,4 @@
-ConcurrentHashMap<String, Object> result = kuzzle
+Map<String, Object> result = kuzzle
     .getCollectionController()
     .getMapping("nyc-open-data", "yellow-taxi")
     .get();

--- a/doc/1/controllers/collection/get-specifications/index.md
+++ b/doc/1/controllers/collection/get-specifications/index.md
@@ -17,7 +17,7 @@ Returns the validation specifications associated to the given index and collecti
 ## Arguments
 
 ```java
-  public CompletableFuture<ConcurrentHashMap<String, Object>> getSpecifications(
+  public CompletableFuture<Map<String, Object>> getSpecifications(
       final String index,
       final String collection)
 ```
@@ -31,7 +31,7 @@ Returns the validation specifications associated to the given index and collecti
 
 ## Returns
 
-Returns a `ConcurrentHashMap<String, Object>` representing the collection specifications.
+Returns a `Map<String, Object>` representing the collection specifications.
 
 ## Usage
 
@@ -46,7 +46,7 @@ Returns a `ConcurrentHashMap<String, Object>` representing the collection specif
 fun getSpecifications(
     index: String,
     collection: String
-  ): CompletableFuture<ConcurrentHashMap<String, Any?>>
+  ): CompletableFuture<Map<String, Any?>>
 ```
 
 | Arguments    | Type              | Description     |
@@ -56,7 +56,7 @@ fun getSpecifications(
 
 ## Returns
 
-Returns a `ConcurrentHashMap<String, Any?>` representing the collection specifications.
+Returns a `Map<String, Any?>` representing the collection specifications.
 
 ## Usage
 

--- a/doc/1/controllers/collection/get-specifications/snippets/get-specifications-java.java
+++ b/doc/1/controllers/collection/get-specifications/snippets/get-specifications-java.java
@@ -1,4 +1,4 @@
-ConcurrentHashMap<String, Object> result = kuzzle
+Map<String, Object> result = kuzzle
     .getCollectionController()
     .getSpecifications("nyc-open-data", "yellow-taxi")
     .get();

--- a/doc/1/controllers/collection/list/index.md
+++ b/doc/1/controllers/collection/list/index.md
@@ -18,7 +18,7 @@ The returned list is sorted in alphanumerical order.
 ## Arguments
 
 ```java
-public CompletableFuture<ConcurrentHashMap<String, Object>> list(
+public CompletableFuture<Map<String, Object>> list(
       final String index) throws NotConnectedException, InternalException
 ```
 
@@ -29,7 +29,7 @@ public CompletableFuture<ConcurrentHashMap<String, Object>> list(
 
 ## Returns
 
-Returns a `ConcurrentHashMap<String, Object>` containing the following properties:
+Returns a `Map<String, Object>` containing the following properties:
 
 | Property      | Type                | Description                                                        |
 | ------------- | ------------------- | ------------------------------------------------------------------ |
@@ -55,7 +55,7 @@ Each object in the `collections` array contains the following properties:
 ## Arguments
 
 ```kotlin
-fun list(index: String): CompletableFuture<ConcurrentHashMap<String, Any?>>
+fun list(index: String): CompletableFuture<Map<String, Any?>>
 ```
 
 
@@ -65,7 +65,7 @@ fun list(index: String): CompletableFuture<ConcurrentHashMap<String, Any?>>
 
 ## Returns
 
-Returns a `ConcurrentHashMap<String, Any?>` containing the following properties:
+Returns a `Map<String, Any?>` containing the following properties:
 
 | Property      | Type                | Description                                                        |
 | ------------- | ------------------- | ------------------------------------------------------------------ |

--- a/doc/1/controllers/collection/list/snippets/list-java.java
+++ b/doc/1/controllers/collection/list/snippets/list-java.java
@@ -1,4 +1,4 @@
-  ConcurrentHashMap<String, Object> result = kuzzle
+  Map<String, Object> result = kuzzle
       .getCollectionController()
       .list("nyc-open-data")
       .get();

--- a/doc/1/controllers/collection/search-specifications/index.md
+++ b/doc/1/controllers/collection/search-specifications/index.md
@@ -26,22 +26,22 @@ When processing a large number of items (i.e. more than 1000), it is advised to 
 
 ```java
 public CompletableFuture<SearchResult> searchSpecifications(
-      ConcurrentHashMap<String, Object> searchQuery,
+      Map<String, Object> searchQuery,
       String scroll,
       Integer from,
       Integer size) throws NotConnectedException, InternalException
 
 public CompletableFuture<SearchResult> searchSpecifications(
-      ConcurrentHashMap<String, Object> searchQuery,
+      Map<String, Object> searchQuery,
       String scroll,
       Integer from) throws NotConnectedException, InternalException
 
 public CompletableFuture<SearchResult> searchSpecifications(
-      ConcurrentHashMap<String, Object> searchQuery,
+      Map<String, Object> searchQuery,
       String scroll) throws NotConnectedException, InternalException
 
 public CompletableFuture<SearchResult> searchSpecifications(
-      ConcurrentHashMap<String, Object> searchQuery)
+      Map<String, Object> searchQuery)
 throws NotConnectedException, InternalException
 ```
 
@@ -49,7 +49,7 @@ throws NotConnectedException, InternalException
 
 | Arguments | Type              | Description                           |
 | --------- | ----------------- | ------------------------------------- |
-| `searchQuery`    | <pre>ConcurrentHashMap<String, Object></pre> | An object containing the search query |
+| `searchQuery`    | <pre>Map<String, Object></pre> | An object containing the search query |
 | `from`     | <pre>Integer</pre><br/>(`0`)    | Offset of the first document to fetch                                                                                                                                                                             |
 | `size`     | <pre>Integer</pre><br/>(`10`)   | Maximum number of documents to retrieve per page                                                                                                                                                                  |
 | `scroll`   | <pre>String</pre><br/>(`""`)    | When set, gets a forward-only cursor having its ttl set to the given value (e.g. `1s`; see [elasticsearch time limits](https://www.elastic.co/guide/en/elasticsearch/reference/7.5/common-options.html#time-units)) |
@@ -77,7 +77,7 @@ Returns a [SearchResult](/sdk/jvm/1/core-classes/search-result) object.
 
 ```kotlin
 fun searchSpecifications(
-    searchQuery: ConcurrentHashMap<String, Any?>,
+    searchQuery: Map<String, Any?>,
     scroll: String? = null,
     from: Int = 0,
     size: Int? = null
@@ -88,7 +88,7 @@ fun searchSpecifications(
 
 | Arguments | Type              | Description                           |
 | --------- | ----------------- | ------------------------------------- |
-| `searchQuery`    | <pre>ConcurrentHashMap<String, Any?></pre> | An object containing the search query |
+| `searchQuery`    | <pre>Map<String, Any?></pre> | An object containing the search query |
 | `from`     | <pre>Int</pre><br/>(`0`)    | Offset of the first document to fetch                                                                                                                                                                             |
 | `size`     | <pre>Int</pre><br/>(`10`)   | Maximum number of documents to retrieve per page                                                                                                                                                                  |
 | `scroll`   | <pre>String</pre><br/>(`""`)    | When set, gets a forward-only cursor having its ttl set to the given value (ie `1s`; cf [elasticsearch time limits](https://www.elastic.co/guide/en/elasticsearch/reference/7.5/common-options.html#time-units)) |

--- a/doc/1/controllers/collection/search-specifications/snippets/search-specifications-java.java
+++ b/doc/1/controllers/collection/search-specifications/snippets/search-specifications-java.java
@@ -1,7 +1,7 @@
 
-ConcurrentHashMap<String, Object> searchQuery = new ConcurrentHashMap<>();
-ConcurrentHashMap<String, Object> filters = new ConcurrentHashMap<>();
-ConcurrentHashMap<String, Object> args = new ConcurrentHashMap<>();
+Map<String, Object> searchQuery = new HashMap<>();
+Map<String, Object> filters = new HashMap<>();
+Map<String, Object> args = new HashMap<>();
 
 filters.put("match_all", args);
 searchQuery.put("query", filters);

--- a/doc/1/controllers/collection/search-specifications/snippets/search-specifications-kotlin.kt
+++ b/doc/1/controllers/collection/search-specifications/snippets/search-specifications-kotlin.kt
@@ -1,10 +1,10 @@
-val args: ConcurrentHashMap<String, Any?> = ConcurrentHashMap<String, Any?>()
-val filters: ConcurrentHashMap<String, Any?> =
-ConcurrentHashMap<String, Any?>().apply {
+val args: Map<String, Any?> = Map<String, Any?>()
+val filters: Map<String, Any?> =
+Map<String, Any?>().apply {
   put("match_all", args)
 }
-val searchQuery: ConcurrentHashMap<String, Any?> =
-ConcurrentHashMap<String, Any?>().apply {
+val searchQuery: Map<String, Any?> =
+Map<String, Any?>().apply {
   put("query", filters)
 }
 

--- a/doc/1/controllers/collection/search-specifications/snippets/search-specifications-kotlin.kt
+++ b/doc/1/controllers/collection/search-specifications/snippets/search-specifications-kotlin.kt
@@ -1,10 +1,10 @@
-val args: Map<String, Any?> = Map<String, Any?>()
+val args: Map<String, Any?> = HashMap<String, Any?>()
 val filters: Map<String, Any?> =
-Map<String, Any?>().apply {
+HashMap<String, Any?>().apply {
   put("match_all", args)
 }
 val searchQuery: Map<String, Any?> =
-Map<String, Any?>().apply {
+HashMap<String, Any?>().apply {
   put("query", filters)
 }
 

--- a/doc/1/controllers/collection/update-specifications/index.md
+++ b/doc/1/controllers/collection/update-specifications/index.md
@@ -18,10 +18,10 @@ When the validation specification is not formatted correctly, a detailed error m
 ## Arguments
 
 ```java
-public CompletableFuture<ConcurrentHashMap<String, Object>> updateSpecifications(
+public CompletableFuture<Map<String, Object>> updateSpecifications(
       final String index,
       final String collection,
-      final ConcurrentHashMap<String, Object> specifications)
+      final Map<String, Object> specifications)
 ```
 
 <br/>
@@ -30,17 +30,17 @@ public CompletableFuture<ConcurrentHashMap<String, Object>> updateSpecifications
 | ---------------- | -------------------------------------------- | ------------------------ |
 | `index`          | <pre>String</pre>                            | Index name               |
 | `collection`     | <pre>String</pre>                            | Collection name          |
-| `specifications` | <pre>ConcurrentHashMap<String, Object></pre> | Specifications to update |
+| `specifications` | <pre>Map<String, Object></pre> | Specifications to update |
 
 ### specifications
 
-A `ConcurrentHashMap<String, Object>` representing the specifications.
+A `Map<String, Object>` representing the specifications.
 
 It must follow the [Specification Structure](/core/2/guides/advanced/data-validation).
 
 ## Returns
 
-Returns a `ConcurrentHashMap<String, Object>` containing the specifications.
+Returns a `Map<String, Object>` containing the specifications.
 
 ## Usage
 
@@ -55,8 +55,8 @@ Returns a `ConcurrentHashMap<String, Object>` containing the specifications.
 fun updateSpecifications(
       index: String,
       collection: String,
-      definition: ConcurrentHashMap<String, Any?>
-      ): CompletableFuture<ConcurrentHashMap<String, Any?>>
+      definition: Map<String, Any?>
+      ): CompletableFuture<Map<String, Any?>>
 ```
 
 <br/>
@@ -65,17 +65,17 @@ fun updateSpecifications(
 | ---------------- | -------------------------------------------- | ------------------------ |
 | `index`          | <pre>String</pre>                            | Index name               |
 | `collection`     | <pre>String</pre>                            | Collection name          |
-| `specifications` | <pre>ConcurrentHashMap<String, Any?></pre> | Specifications to update |
+| `specifications` | <pre>Map<String, Any?></pre> | Specifications to update |
 
 ### specifications
 
-A `ConcurrentHashMap<String, Any?>` object representing the specifications.
+A `Map<String, Any?>` object representing the specifications.
 
 It must follow the [Specification Structure](/core/2/guides/advanced/data-validation).
 
 ## Returns
 
-Returns a `ConcurrentHashMap<String, Any?>` containing the specifications.
+Returns a `Map<String, Any?>` containing the specifications.
 
 
 ## Usage

--- a/doc/1/controllers/collection/update-specifications/snippets/update-specifications-java.java
+++ b/doc/1/controllers/collection/update-specifications/snippets/update-specifications-java.java
@@ -1,6 +1,6 @@
-    ConcurrentHashMap<String, Object> specifications = new ConcurrentHashMap<>();
-    ConcurrentHashMap<String, Object> fields = new ConcurrentHashMap<>();
-    ConcurrentHashMap<String, Object> license = new ConcurrentHashMap<>();
+    Map<String, Object> specifications = new HashMap<>();
+    Map<String, Object> fields = new HashMap<>();
+    Map<String, Object> license = new HashMap<>();
 
     specifications.put("strict", false);
     license.put("mandatory", true);
@@ -8,7 +8,7 @@
     fields.put("license", license);
     specifications.put("fields", fields);
 
-    ConcurrentHashMap<String, Object> result = kuzzle
+    Map<String, Object> result = kuzzle
         .getCollectionController()
         .updateSpecifications("nyc-open-data", "yellow-taxi", specifications)
         .get();

--- a/doc/1/controllers/collection/update-specifications/snippets/update-specifications-kotlin.kt
+++ b/doc/1/controllers/collection/update-specifications/snippets/update-specifications-kotlin.kt
@@ -1,19 +1,19 @@
 
-val license: ConcurrentHashMap<String, Any?> =
-ConcurrentHashMap<String, Any?>().apply {
+val license: Map<String, Any?> =
+Map<String, Any?>().apply {
   put("mandatory", true);
   put("type", "string");
 };
-val fields: ConcurrentHashMap<String, Any?> =
-ConcurrentHashMap<String, Any?>().apply {
+val fields: Map<String, Any?> =
+Map<String, Any?>().apply {
   put("license", license);
 };
-val specifications: ConcurrentHashMap<String, Any?> =
-ConcurrentHashMap<String, Any?>().apply{
+val specifications: Map<String, Any?> =
+Map<String, Any?>().apply{
   put("strict", false);
   put("fields", fields);
 };
-val result: ConcurrentHashMap<String, Any?> = kuzzle
+val result: Map<String, Any?> = kuzzle
     .collectionController
     .updateSpecifications("nyc-open-data", "yellow-taxi", specifications)
     .get();

--- a/doc/1/controllers/collection/update-specifications/snippets/update-specifications-kotlin.kt
+++ b/doc/1/controllers/collection/update-specifications/snippets/update-specifications-kotlin.kt
@@ -1,15 +1,15 @@
 
 val license: Map<String, Any?> =
-Map<String, Any?>().apply {
+HashMap<String, Any?>().apply {
   put("mandatory", true);
   put("type", "string");
 };
 val fields: Map<String, Any?> =
-Map<String, Any?>().apply {
+HashMap<String, Any?>().apply {
   put("license", license);
 };
 val specifications: Map<String, Any?> =
-Map<String, Any?>().apply{
+HashMap<String, Any?>().apply{
   put("strict", false);
   put("fields", fields);
 };

--- a/doc/1/controllers/collection/update/index.md
+++ b/doc/1/controllers/collection/update/index.md
@@ -24,10 +24,10 @@ You can also provide Elasticsearch [index settings](https://www.elastic.co/guide
 ## Arguments
 
 ```java
-public CompletableFuture<ConcurrentHashMap<String, Object>> update(
+public CompletableFuture<Map<String, Object>> update(
       final String index,
       final String collection,
-      final ConcurrentHashMap<String, Object> definition)
+      final Map<String, Object> definition)
 
 ```
 
@@ -37,7 +37,7 @@ public CompletableFuture<ConcurrentHashMap<String, Object>> update(
 |--------------|-------------------|-------------------------------------------------------------|
 | `index`      | <pre>String</pre> | Index name                                                  |
 | `collection` | <pre>String</pre> | Collection name                                             |
-| `definition` | <pre>ConcurrentHashMap<String, Object></pre> | Describes the collection mappings and the ES index settings |
+| `definition` | <pre>Map<String, Object></pre> | Describes the collection mappings and the ES index settings |
 
 ### definition
 
@@ -77,7 +77,7 @@ An object containing:
 fun update(
     index: String,
     collection: String,
-    definition: ConcurrentHashMap<String, Any?>
+    definition: Map<String, Any?>
   ): CompletableFuture<Void>
 ```
 
@@ -87,7 +87,7 @@ fun update(
 |--------------|-------------------|-------------------------------------------------------------|
 | `index`      | <pre>String</pre> | Index name                                                  |
 | `collection` | <pre>String</pre> | Collection name                                             |
-| `definition` | <pre>ConcurrentHashMap<String, Any?></pre> | Describes the collection mappings and the ES index settings |
+| `definition` | <pre>Map<String, Any?></pre> | Describes the collection mappings and the ES index settings |
 
 ### definition
 

--- a/doc/1/controllers/collection/update/snippets/update-java.java
+++ b/doc/1/controllers/collection/update/snippets/update-java.java
@@ -1,7 +1,7 @@
-ConcurrentHashMap<String, Object> definition = new ConcurrentHashMap<>();
-ConcurrentHashMap<String, Object> properties = new ConcurrentHashMap<>();
-ConcurrentHashMap<String, Object> _meta = new ConcurrentHashMap<>();
-ConcurrentHashMap<String, Object> plate = new ConcurrentHashMap<>();
+Map<String, Object> definition = new HashMap<>();
+Map<String, Object> properties = new HashMap<>();
+Map<String, Object> _meta = new HashMap<>();
+Map<String, Object> plate = new HashMap<>();
 
 plate.put("type", "keyword");
 _meta.put("area", "Panipokhari");

--- a/doc/1/controllers/collection/update/snippets/update-kotlin.kt
+++ b/doc/1/controllers/collection/update/snippets/update-kotlin.kt
@@ -1,20 +1,20 @@
-val plate: ConcurrentHashMap<String, Any?> =
-ConcurrentHashMap<String, Any?>().apply{
+val plate: Map<String, Any?> =
+Map<String, Any?>().apply{
   put("type", "keyword")
 }
 
-val _meta: ConcurrentHashMap<String, Any?> =
-ConcurrentHashMap<String, Any?>().apply{
+val _meta: Map<String, Any?> =
+Map<String, Any?>().apply{
   put("area", "Panipokhari")
 }
 
-val properties: ConcurrentHashMap<String, Any?> =
-ConcurrentHashMap<String, Any?>().apply{
+val properties: Map<String, Any?> =
+Map<String, Any?>().apply{
   put("plate", plate)
 }
 
-val definition: ConcurrentHashMap<String, Any?> =
-ConcurrentHashMap<String, Any?>().apply{
+val definition: Map<String, Any?> =
+Map<String, Any?>().apply{
   put("dynamic", false)
   put("_meta", _meta)
   put("properties", properties)

--- a/doc/1/controllers/collection/update/snippets/update-kotlin.kt
+++ b/doc/1/controllers/collection/update/snippets/update-kotlin.kt
@@ -1,20 +1,20 @@
 val plate: Map<String, Any?> =
-Map<String, Any?>().apply{
+HashMap<String, Any?>().apply{
   put("type", "keyword")
 }
 
 val _meta: Map<String, Any?> =
-Map<String, Any?>().apply{
+HashMap<String, Any?>().apply{
   put("area", "Panipokhari")
 }
 
 val properties: Map<String, Any?> =
-Map<String, Any?>().apply{
+HashMap<String, Any?>().apply{
   put("plate", plate)
 }
 
 val definition: Map<String, Any?> =
-Map<String, Any?>().apply{
+HashMap<String, Any?>().apply{
   put("dynamic", false)
   put("_meta", _meta)
   put("properties", properties)

--- a/doc/1/controllers/collection/validate-specifications/index.md
+++ b/doc/1/controllers/collection/validate-specifications/index.md
@@ -19,10 +19,10 @@ When the validation specification is not formatted correctly, a detailed error m
 ## Arguments
 
 ```java
-  public CompletableFuture<ConcurrentHashMap<String, Object>> validateSpecifications(
+  public CompletableFuture<Map<String, Object>> validateSpecifications(
       final String index,
       final String collection,
-      final ConcurrentHashMap<String, Object> specifications)
+      final Map<String, Object> specifications)
 ```
 
 <br/>
@@ -31,17 +31,17 @@ When the validation specification is not formatted correctly, a detailed error m
 | ---------------- | -------------------------------------------- | -------------------------- |
 | `index`          | <pre>String</pre>                            | Index name                 |
 | `collection`     | <pre>String</pre>                            | Collection name            |
-| `specifications` | <pre>ConcurrentHashMap<String, Object></pre> | Specifications to validate |
+| `specifications` | <pre>Map<String, Object></pre> | Specifications to validate |
 
 ### specifications
 
-A `ConcurrentHashMap<String, Object>` representing the specifications.
+A `Map<String, Object>` representing the specifications.
 
 This object must follow the [Specification Structure](/core/2/guides/advanced/data-validation).
 
 ## Returns
 
-Returns a `ConcurrentHashMap<String, Object>` which contains information about the specifications validity.
+Returns a `Map<String, Object>` which contains information about the specifications validity.
 
 It contains the following properties:
 
@@ -64,8 +64,8 @@ It contains the following properties:
 fun validateSpecifications(
     index: String,
     collection: String,
-    specifications: ConcurrentHashMap<String, Any>?
-  ): CompletableFuture<ConcurrentHashMap<String, Any?>>
+    specifications: Map<String, Any>?
+  ): CompletableFuture<Map<String, Any?>>
 ```
 
 <br/>
@@ -74,17 +74,17 @@ fun validateSpecifications(
 | ---------------- | -------------------------------------------- | -------------------------- |
 | `index`          | <pre>String</pre>                            | Index name                 |
 | `collection`     | <pre>String</pre>                            | Collection name            |
-| `specifications` | <pre>ConcurrentHashMap<String, Any?></pre> | Specifications to validate |
+| `specifications` | <pre>Map<String, Any?></pre> | Specifications to validate |
 
 ### specifications
 
-A `ConcurrentHashMap<String, Any?>` representing the specifications.
+A `Map<String, Any?>` representing the specifications.
 
 This object must follow the [Specification Structure](/core/2/guides/advanced/data-validation).
 
 ## Returns
 
-Returns a `ConcurrentHashMap<String, Any?>` which contains information about the specifications validity.
+Returns a `Map<String, Any?>` which contains information about the specifications validity.
 
 It contains the following properties:
 

--- a/doc/1/controllers/collection/validate-specifications/snippets/validate-specifications-java.java
+++ b/doc/1/controllers/collection/validate-specifications/snippets/validate-specifications-java.java
@@ -1,6 +1,6 @@
-    ConcurrentHashMap<String, Object> specifications = new ConcurrentHashMap<>();
-    ConcurrentHashMap<String, Object> fields = new ConcurrentHashMap<>();
-    ConcurrentHashMap<String, Object> license = new ConcurrentHashMap<>();
+    Map<String, Object> specifications = new HashMap<>();
+    Map<String, Object> fields = new HashMap<>();
+    Map<String, Object> license = new HashMap<>();
 
     specifications.put("strict", false);
     license.put("mandatory", true);
@@ -8,7 +8,7 @@
     fields.put("license", license);
     specifications.put("fields", fields);
 
-    ConcurrentHashMap<String, Object> result = kuzzle
+    Map<String, Object> result = kuzzle
         .getCollectionController()
         .validateSpecifications("nyc-open-data", "yellow-taxi", specifications)
         .get();

--- a/doc/1/controllers/collection/validate-specifications/snippets/validate-specifications-kotlin.kt
+++ b/doc/1/controllers/collection/validate-specifications/snippets/validate-specifications-kotlin.kt
@@ -1,11 +1,11 @@
-val license: ConcurrentHashMap<String, Any> = ConcurrentHashMap<String, Any>().apply {
+val license: Map<String, Any> = Map<String, Any>().apply {
   put("type", "symbol")
   put("mandatory", true)
 }
-val fields: ConcurrentHashMap<String, Any> = ConcurrentHashMap<String, Any>().apply {
+val fields: Map<String, Any> = Map<String, Any>().apply {
   put("license", license)
 }
-val specifications: ConcurrentHashMap<String, Any> = ConcurrentHashMap<String, Any>().apply {
+val specifications: Map<String, Any> = Map<String, Any>().apply {
   put("strict", false)
   put("fields", fields)
 }

--- a/doc/1/controllers/collection/validate-specifications/snippets/validate-specifications-kotlin.kt
+++ b/doc/1/controllers/collection/validate-specifications/snippets/validate-specifications-kotlin.kt
@@ -1,11 +1,11 @@
-val license: Map<String, Any> = Map<String, Any>().apply {
+val license: Map<String, Any> = HashMap<String, Any>().apply {
   put("type", "symbol")
   put("mandatory", true)
 }
-val fields: Map<String, Any> = Map<String, Any>().apply {
+val fields: Map<String, Any> = HashMap<String, Any>().apply {
   put("license", license)
 }
-val specifications: Map<String, Any> = Map<String, Any>().apply {
+val specifications: Map<String, Any> = HashMap<String, Any>().apply {
   put("strict", false)
   put("fields", fields)
 }

--- a/doc/1/controllers/document/count/index.md
+++ b/doc/1/controllers/document/count/index.md
@@ -35,7 +35,7 @@ throws NotConnectedException, InternalException
 | ------------------ | -------------------------------------------- | --------------- |
 | `index`            | <pre>String</pre>                            | Index name      |
 | `collection`       | <pre>String</pre>                            | Collection name |
-| `searchQuery`      | <pre>ConcurrentHashMap<String, Object></pre><br>(`{}`) | Query to match  |
+| `searchQuery`      | <pre>Map<String, Object></pre><br>(`{}`) | Query to match  |
 
 ---
 
@@ -56,14 +56,14 @@ Returns an Integer.
 fun count(
       index: String,
       collection: String,
-      searchQuery: ConcurrentHashMap<String, Any?> = ConcurrentHashMap<String, Any?>()): CompletableFuture<Int>
+      searchQuery: Map<String, Any?> = Map<String, Any?>()): CompletableFuture<Int>
 ```
 
 | Argument           | Type                                         | Description     |
 | ------------------ | -------------------------------------------- | --------------- |
 | `index`            | <pre>String</pre>                            | Index name      |
 | `collection`       | <pre>String</pre>                            | Collection name |
-| `searchQuery`      | <pre>ConcurrentHashMap<String, Any?></pre><br>(`{}`) | Query to match  |
+| `searchQuery`      | <pre>Map<String, Any?></pre><br>(`{}`) | Query to match  |
 
 ---
 

--- a/doc/1/controllers/document/count/index.md
+++ b/doc/1/controllers/document/count/index.md
@@ -56,7 +56,7 @@ Returns an Integer.
 fun count(
       index: String,
       collection: String,
-      searchQuery: Map<String, Any?> = Map<String, Any?>()): CompletableFuture<Int>
+      searchQuery: Map<String, Any?> = HashMap<String, Any?>()): CompletableFuture<Int>
 ```
 
 | Argument           | Type                                         | Description     |

--- a/doc/1/controllers/document/count/snippets/count-java.java
+++ b/doc/1/controllers/document/count/snippets/count-java.java
@@ -1,5 +1,5 @@
-ConcurrentHashMap<String, Object> searchQuery = new ConcurrentHashMap<>();
-ConcurrentHashMap<String, Object> match = new ConcurrentHashMap<>();
+Map<String, Object> searchQuery = new HashMap<>();
+Map<String, Object> match = new HashMap<>();
 match.put("Hello", "Clarisse");
 searchQuery.put("match", match);
 

--- a/doc/1/controllers/document/count/snippets/count-kotlin.kt
+++ b/doc/1/controllers/document/count/snippets/count-kotlin.kt
@@ -1,6 +1,6 @@
-val searchQuery : ConcurrentHashMap<String, Any?> =
-    ConcurrentHashMap<String, Any?>().apply {
-      put("match", ConcurrentHashMap<String, Any?>().apply {
+val searchQuery : Map<String, Any?> =
+    Map<String, Any?>().apply {
+      put("match", Map<String, Any?>().apply {
         put("Hello", "Clarisse")
       })
     }

--- a/doc/1/controllers/document/count/snippets/count-kotlin.kt
+++ b/doc/1/controllers/document/count/snippets/count-kotlin.kt
@@ -1,6 +1,6 @@
 val searchQuery : Map<String, Any?> =
-    Map<String, Any?>().apply {
-      put("match", Map<String, Any?>().apply {
+    HashMap<String, Any?>().apply {
+      put("match", HashMap<String, Any?>().apply {
         put("Hello", "Clarisse")
       })
     }

--- a/doc/1/controllers/document/create-or-replace/index.md
+++ b/doc/1/controllers/document/create-or-replace/index.md
@@ -17,18 +17,18 @@ Creates a new document in the persistent data storage, or replaces its content i
 ## Arguments
 
 ```java
-public CompletableFuture<ConcurrentHashMap<String, Object>> createOrReplace(
+public CompletableFuture<Map<String, Object>> createOrReplace(
       String index,
       String collection,
       String id,
-      ConcurrentHashMap<String, Object> document)
+      Map<String, Object> document)
 throws NotConnectedException, InternalException
 
-public CompletableFuture<ConcurrentHashMap<String, Object>> createOrReplace(
+public CompletableFuture<Map<String, Object>> createOrReplace(
       String index,
       String collection,
       String id,
-      ConcurrentHashMap<String, Object> document,
+      Map<String, Object> document,
       Boolean waitForRefresh)
 throws NotConnectedException, InternalException
 ```
@@ -38,18 +38,18 @@ throws NotConnectedException, InternalException
 | `index`            | <pre>String</pre>                            | Index                             |
 | `collection`       | <pre>String</pre>                            | Collection                        |
 | `id`               | <pre>String</pre>                            | Document ID                       |
-| `document`         | <pre>ConcurrentHashMap<String, Object></pre> | Document content                  |
+| `document`         | <pre>Map<String, Object></pre> | Document content                  |
 | `waitForRefresh`   | <pre>Boolean</pre>                           | If set to `true`, Kuzzle will wait for the persistence layer to finish indexing|
 
 ---
 
 ## Return
 
-A `ConcurrentHashMap` which has the following properties:
+A `Map` which has the following properties:
 
 | Property     | Type                         | Description                      |
 |------------- |----------------------------- |--------------------------------- |
-| `_source`    | <pre>ConcurrentHashMap</pre> | Document content                 |
+| `_source`    | <pre>Map</pre> | Document content                 |
 | `_id`        | <pre>String</pre>            | ID of the document                       |
 | `_version`   | <pre>Integer</pre>           | Version of the document in the persistent data storage |
 
@@ -67,8 +67,8 @@ fun createOrReplace(
   index: String,
   collection: String,
   id: String,
-  document: ConcurrentHashMap<String, Any?>,
-  waitForRefresh: Boolean? = null): CompletableFuture<ConcurrentHashMap<String, Any?>>
+  document: Map<String, Any?>,
+  waitForRefresh: Boolean? = null): CompletableFuture<Map<String, Any?>>
 ```
 
 | Arguments          | Type                                         | Description                       |
@@ -76,18 +76,18 @@ fun createOrReplace(
 | `index`            | <pre>String</pre>                            | Index                             |
 | `collection`       | <pre>String</pre>                            | Collection                        |
 | `id`               | <pre>String</pre>                            | Document ID                       |
-| `document`         | <pre>ConcurrentHashMap<String, Any?></pre> | Document content                  |
+| `document`         | <pre>Map<String, Any?></pre> | Document content                  |
 | `waitForRefresh`   | <pre>Boolean</pre><br>(`null`)               | If set to `true`, Kuzzle will wait for the persistence layer to finish indexing|
 
 ---
 
 ## Return
 
-A `ConcurrentHashMap` which has the following properties:
+A `Map` which has the following properties:
 
 | Property     | Type                         | Description                      |
 |------------- |----------------------------- |--------------------------------- |
-| `_source`    | <pre>ConcurrentHashMap</pre> | Document content                 |
+| `_source`    | <pre>Map</pre> | Document content                 |
 | `_id`        | <pre>String</pre>            | ID of the document                       |
 | `_version`   | <pre>Int</pre>           | Version of the document in the persistent data storage |
 

--- a/doc/1/controllers/document/create-or-replace/snippets/create-or-replace-java.java
+++ b/doc/1/controllers/document/create-or-replace/snippets/create-or-replace-java.java
@@ -1,8 +1,8 @@
 
-  ConcurrentHashMap<String, Object> document = new ConcurrentHashMap<>();
+  Map<String, Object> document = new HashMap<>();
   document.put("firstname", "John");
 
-  ConcurrentHashMap<String, Object> result = kuzzle
+  Map<String, Object> result = kuzzle
     .getDocumentController()
     .createOrReplace("nyc-open-data", "yellow-taxi", "some-id", document)
     .get();

--- a/doc/1/controllers/document/create-or-replace/snippets/create-or-replace-kotlin.kt
+++ b/doc/1/controllers/document/create-or-replace/snippets/create-or-replace-kotlin.kt
@@ -1,8 +1,8 @@
-val document: ConcurrentHashMap<String, Any?> = ConcurrentHashMap<String, Any?>().apply {
+val document: Map<String, Any?> = Map<String, Any?>().apply {
   put("firstname", "John")
 }
 
-val result: ConcurrentHashMap<String, Any?> =
+val result: Map<String, Any?> =
     kuzzle
         .documentController
         .createOrReplace("nyc-open-data", "yellow-taxi", "some-id", document)

--- a/doc/1/controllers/document/create-or-replace/snippets/create-or-replace-kotlin.kt
+++ b/doc/1/controllers/document/create-or-replace/snippets/create-or-replace-kotlin.kt
@@ -1,4 +1,4 @@
-val document: Map<String, Any?> = Map<String, Any?>().apply {
+val document: Map<String, Any?> = HashMap<String, Any?>().apply {
   put("firstname", "John")
 }
 

--- a/doc/1/controllers/document/create/index.md
+++ b/doc/1/controllers/document/create/index.md
@@ -21,23 +21,23 @@ The optional parameter `waitForRefresh` can be used with the value `true` in ord
 ## Arguments
 
 ```java
-public CompletableFuture<ConcurrentHashMap<String, Object>> create(
+public CompletableFuture<Map<String, Object>> create(
       String index,
       String collection,
-      ConcurrentHashMap<String, Object> document)
+      Map<String, Object> document)
 throws NotConnectedException, InternalException
 
-public CompletableFuture<ConcurrentHashMap<String, Object>> create(
+public CompletableFuture<Map<String, Object>> create(
       String index,
       String collection,
-      ConcurrentHashMap<String, Object> document,
+      Map<String, Object> document,
       String id)
 throws NotConnectedException, InternalException
 
-public CompletableFuture<ConcurrentHashMap<String, Object>> create(
+public CompletableFuture<Map<String, Object>> create(
       String index,
       String collection,
-      ConcurrentHashMap<String, Object> document,
+      Map<String, Object> document,
       String id,
       Boolean waitForRefresh)
 throws NotConnectedException, InternalException
@@ -47,7 +47,7 @@ throws NotConnectedException, InternalException
 | ------------------ | -------------------------------------------- | --------------------------------- |
 | `index`            | <pre>String</pre>                            | Index                             |
 | `collection`       | <pre>String</pre>                            | Collection                        |
-| `document`         | <pre>ConcurrentHashMap<String, Object></pre> | Document content |
+| `document`         | <pre>Map<String, Object></pre> | Document content |
 | `id`               | <pre>String</pre> (optional)                 | Document identifier. Auto-generated if not specified              |
 | `waitForRefresh`   | <pre>Boolean</pre> (optional)                | If set to `true`, Kuzzle will wait for the persistence layer to finish indexing|
 
@@ -55,11 +55,11 @@ throws NotConnectedException, InternalException
 
 ## Return
 
-A `ConcurrentHashMap` which has the following properties:
+A `Map` which has the following properties:
 
 | Property     | Type                         | Description                      |
 |------------- |----------------------------- |--------------------------------- |
-| `_source`    | <pre>ConcurrentHashMap</pre> | Created document                 |
+| `_source`    | <pre>Map</pre> | Created document                 |
 | `_id`        | <pre>String</pre>            | ID of the newly created document                       |
 | `_version`   | <pre>Integer</pre>           | Version of the document in the persistent data storage |
 
@@ -76,16 +76,16 @@ A `ConcurrentHashMap` which has the following properties:
 fun create(
   index: String,
   collection: String,
-  document: ConcurrentHashMap<String, Any?>,
+  document: Map<String, Any?>,
   id: String? = null,
-  waitForRefresh: Boolean? = null): CompletableFuture<ConcurrentHashMap<String, Any?>>
+  waitForRefresh: Boolean? = null): CompletableFuture<Map<String, Any?>>
 ```
 
 | Arguments          | Type                                         | Description                       |
 | ------------------ | -------------------------------------------- | --------------------------------- |
 | `index`            | <pre>String</pre>                            | Index                             |
 | `collection`       | <pre>String</pre>                            | Collection                        |
-| `document`         | <pre>ConcurrentHashMap<String, Any?></pre> | Document content |
+| `document`         | <pre>Map<String, Any?></pre> | Document content |
 | `id`               | <pre>String</pre> (optional)                 | Document identifier. Auto-generated if not specified              |
 | `waitForRefresh`   | <pre>Boolean</pre> (optional)                | If set to `true`, Kuzzle will wait for the persistence layer to finish indexing|
 
@@ -93,11 +93,11 @@ fun create(
 
 ## Return
 
-A `ConcurrentHashMap` which has the following properties:
+A `Map` which has the following properties:
 
 | Property     | Type                         | Description                      |
 |------------- |----------------------------- |--------------------------------- |
-| `_source`    | <pre>ConcurrentHashMap</pre> | Created document                 |
+| `_source`    | <pre>Map</pre> | Created document                 |
 | `_id`        | <pre>String</pre>            | ID of the newly created document                       |
 | `_version`   | <pre>Int</pre>           | Version of the document in the persistent data storage |
 

--- a/doc/1/controllers/document/create/snippets/create-java.java
+++ b/doc/1/controllers/document/create/snippets/create-java.java
@@ -1,7 +1,7 @@
-ConcurrentHashMap<String, Object> document = new ConcurrentHashMap<>();
+Map<String, Object> document = new HashMap<>();
 document.put("firstname", "John");
 
-ConcurrentHashMap<String, Object> result =
+Map<String, Object> result =
     kuzzle
       .getDocumentController()
       .create("nyc-open-data", "yellow-taxi", document)

--- a/doc/1/controllers/document/create/snippets/create-kotlin.kt
+++ b/doc/1/controllers/document/create/snippets/create-kotlin.kt
@@ -1,8 +1,8 @@
-val document: ConcurrentHashMap<String, Any?> = ConcurrentHashMap<String, Any?>().apply {
+val document: Map<String, Any?> = Map<String, Any?>().apply {
   put("firstname", "John")
 }
 
-val result: ConcurrentHashMap<String, Any?> =
+val result: Map<String, Any?> =
     kuzzle
       .documentController
       .create("nyc-open-data", "yellow-taxi", document)

--- a/doc/1/controllers/document/create/snippets/create-kotlin.kt
+++ b/doc/1/controllers/document/create/snippets/create-kotlin.kt
@@ -1,4 +1,4 @@
-val document: Map<String, Any?> = Map<String, Any?>().apply {
+val document: Map<String, Any?> = HashMap<String, Any?>().apply {
   put("firstname", "John")
 }
 

--- a/doc/1/controllers/document/delete-by-query/index.md
+++ b/doc/1/controllers/document/delete-by-query/index.md
@@ -22,12 +22,12 @@ An empty or null query will match all documents in the collection.
   public CompletableFuture<ArrayList<String>> deleteByQuery(
       String index,
       String collection,
-      ConcurrentHashMap<String, Object> searchQuery) throws NotConnectedException, InternalException
+      Map<String, Object> searchQuery) throws NotConnectedException, InternalException
 
   public CompletableFuture<ArrayList<String>> deleteByQuery(
       String index,
       String collection,
-      ConcurrentHashMap<String, Object> searchQuery,
+      Map<String, Object> searchQuery,
       Boolean waitForRefresh) throws NotConnectedException, InternalException
 ```
 
@@ -35,7 +35,7 @@ An empty or null query will match all documents in the collection.
 | ------------------ | -------------------------------------------- | --------------- |
 | `index`            | <pre>String</pre>                            | Index name      |
 | `collection`       | <pre>String</pre>                            | Collection name |
-| `searchQuery`      | <pre>ConcurrentHashMap<String, Object></pre> | Query to match  |
+| `searchQuery`      | <pre>Map<String, Object></pre> | Query to match  |
 | `waitForRefresh`   | <pre>Boolean</pre> (optional)                | If set to `true`, Kuzzle will wait for the persistence layer to finish indexing|
 
 ---
@@ -57,7 +57,7 @@ Returns an `ArrayList<String>` containing the deleted document ids.
 fun deleteByQuery(
       index: String,
       collection: String,
-      searchQuery: ConcurrentHashMap<String, Any?>,
+      searchQuery: Map<String, Any?>,
       waitForRefresh: Boolean? = null): CompletableFuture<ArrayList<String>>
 ```
 
@@ -65,7 +65,7 @@ fun deleteByQuery(
 | ------------------ | -------------------------------------------- | --------------- |
 | `index`            | <pre>String</pre>                            | Index name      |
 | `collection`       | <pre>String</pre>                            | Collection name |
-| `searchQuery`      | <pre>ConcurrentHashMap<String, Any?></pre> | Query to match  |
+| `searchQuery`      | <pre>Map<String, Any?></pre> | Query to match  |
 | `waitForRefresh`   | <pre>Boolean</pre> (optional)                | If set to `true`, Kuzzle will wait for the persistence layer to finish indexing|
 
 ---

--- a/doc/1/controllers/document/delete-by-query/snippets/delete-by-query-java.java
+++ b/doc/1/controllers/document/delete-by-query/snippets/delete-by-query-java.java
@@ -1,6 +1,6 @@
-    ConcurrentHashMap<String, Object> searchQuery = new ConcurrentHashMap<>();
-    ConcurrentHashMap<String, Object> query = new ConcurrentHashMap<>();
-    ConcurrentHashMap<String, Object> match = new ConcurrentHashMap<>();
+    Map<String, Object> searchQuery = new HashMap<>();
+    Map<String, Object> query = new HashMap<>();
+    Map<String, Object> match = new HashMap<>();
     match.put("capacity", 4);
     query.put("match", match);
     searchQuery.put("query", query);

--- a/doc/1/controllers/document/delete-by-query/snippets/delete-by-query-kotlin.kt
+++ b/doc/1/controllers/document/delete-by-query/snippets/delete-by-query-kotlin.kt
@@ -1,6 +1,6 @@
-val searchQuery: ConcurrentHashMap<String, Any?> = ConcurrentHashMap<String, Any?>().apply {
-  put("query", ConcurrentHashMap<String, Any?>().apply {
-    put("match", ConcurrentHashMap<String, Any?>().apply {
+val searchQuery: Map<String, Any?> = Map<String, Any?>().apply {
+  put("query", Map<String, Any?>().apply {
+    put("match", Map<String, Any?>().apply {
       put("capacity", 4)
     })
   })

--- a/doc/1/controllers/document/delete-by-query/snippets/delete-by-query-kotlin.kt
+++ b/doc/1/controllers/document/delete-by-query/snippets/delete-by-query-kotlin.kt
@@ -1,6 +1,6 @@
-val searchQuery: Map<String, Any?> = Map<String, Any?>().apply {
-  put("query", Map<String, Any?>().apply {
-    put("match", Map<String, Any?>().apply {
+val searchQuery: Map<String, Any?> = HashMap<String, Any?>().apply {
+  put("query", HashMap<String, Any?>().apply {
+    put("match", HashMap<String, Any?>().apply {
       put("capacity", 4)
     })
   })

--- a/doc/1/controllers/document/delete/index.md
+++ b/doc/1/controllers/document/delete/index.md
@@ -17,13 +17,13 @@ Deletes a document.
 ## Arguments
 
 ```java
-public CompletableFuture<ConcurrentHashMap<String, Object>> delete(
+public CompletableFuture<Map<String, Object>> delete(
       String index,
       String collection,
       String id)
 throws NotConnectedException, InternalException
 
-public CompletableFuture<ConcurrentHashMap<String, Object>> delete(
+public CompletableFuture<Map<String, Object>> delete(
       String index,
       String collection,
       String id,
@@ -42,7 +42,7 @@ throws NotConnectedException, InternalException
 
 ## Return
 
-A `ConcurrentHashMap` which has the following property:
+A `Map` which has the following property:
 
 | Property     | Type                         | Description                      |
 |------------- |----------------------------- |--------------------------------- |
@@ -62,7 +62,7 @@ fun delete(
       index: String,
       collection: String,
       id: String?,
-      waitForRefresh: Boolean? = null): CompletableFuture<ConcurrentHashMap<String, Any?>>
+      waitForRefresh: Boolean? = null): CompletableFuture<Map<String, Any?>>
 ```
 
 | Arguments          | Type                                         | Description                       |
@@ -76,7 +76,7 @@ fun delete(
 
 ## Return
 
-A `ConcurrentHashMap` which has the following property:
+A `Map` which has the following property:
 
 | Property     | Type                         | Description                      |
 |------------- |----------------------------- |--------------------------------- |

--- a/doc/1/controllers/document/get/index.md
+++ b/doc/1/controllers/document/get/index.md
@@ -17,7 +17,7 @@ Gets a document.
 ## Arguments
  
 ```java
-public CompletableFuture<ConcurrentHashMap<String, Object>> get(
+public CompletableFuture<Map<String, Object>> get(
       String index,
       String collection,
       String id)
@@ -35,11 +35,11 @@ throws NotConnectedException, InternalException
 
 ## Return
 
-A `ConcurrentHashMap` which has the following properties:
+A `Map` which has the following properties:
 
 | Property     | Type                         | Description                                                    |
 |------------- |----------------------------- |--------------------------------------------------------------- |
-| `_source`    | <pre>ConcurrentHashMap</pre> | Document content                |
+| `_source`    | <pre>Map</pre> | Document content                |
 | `_id`        | <pre>String</pre>            | ID of the document                                     |
 | `_version`   | <pre>Integer</pre>           | Version of the document in the persistent data storage         |
 
@@ -56,7 +56,7 @@ A `ConcurrentHashMap` which has the following properties:
 fun get(
       index: String,
       collection: String,
-      id: String): CompletableFuture<ConcurrentHashMap<String, Any?>>
+      id: String): CompletableFuture<Map<String, Any?>>
 
 ```
  
@@ -70,11 +70,11 @@ fun get(
 
 ## Return
 
-A `ConcurrentHashMap` which has the following properties:
+A `Map` which has the following properties:
 
 | Property     | Type                         | Description                                                    |
 |------------- |----------------------------- |--------------------------------------------------------------- |
-| `_source`    | <pre>ConcurrentHashMap</pre> | Document content                |
+| `_source`    | <pre>Map</pre> | Document content                |
 | `_id`        | <pre>String</pre>            | ID of the document                                     |
 | `_version`   | <pre>Integer</pre>           | Version of the document in the persistent data storage         |
 

--- a/doc/1/controllers/document/get/snippets/get-java.java
+++ b/doc/1/controllers/document/get/snippets/get-java.java
@@ -1,4 +1,4 @@
-    ConcurrentHashMap<String, Object> result =
+    Map<String, Object> result =
     kuzzle.getDocumentController().get("nyc-open-data", "yellow-taxi", "some-id")
     .get();
 

--- a/doc/1/controllers/document/get/snippets/get-kotlin.kt
+++ b/doc/1/controllers/document/get/snippets/get-kotlin.kt
@@ -1,4 +1,4 @@
-val result: ConcurrentHashMap<String, Any?> =
+val result: Map<String, Any?> =
     kuzzle
         .documentController
         .get("nyc-open-data", "yellow-taxi", "some-id")

--- a/doc/1/controllers/document/m-create-or-replace/index.md
+++ b/doc/1/controllers/document/m-create-or-replace/index.md
@@ -17,16 +17,16 @@ Creates or replaces multiple documents.
 ## Arguments
 
 ```java
-public CompletableFuture<ConcurrentHashMap<String, ArrayList<Object>>> mCreateOrReplace(
+public CompletableFuture<Map<String, ArrayList<Object>>> mCreateOrReplace(
       String index,
       String collection,
-      ArrayList<ConcurrentHashMap<String, Object>> documents)
+      ArrayList<Map<String, Object>> documents)
 throws NotConnectedException, InternalException
 
-public CompletableFuture<ConcurrentHashMap<String, ArrayList<Object>>> mCreateOrReplace(
+public CompletableFuture<Map<String, ArrayList<Object>>> mCreateOrReplace(
       String index,
       String collection,
-      ArrayList<ConcurrentHashMap<String, Object>> documents,
+      ArrayList<Map<String, Object>> documents,
       Boolean waitForRefresh)
 throws NotConnectedException, InternalException
 ```
@@ -35,7 +35,7 @@ throws NotConnectedException, InternalException
 | ------------------ | ------------------------------------------------------- | --------------------------------- |
 | `index`            | <pre>String</pre>                                       | Index                             |
 | `collection`       | <pre>String</pre>                                       | Collection                        |
-| `documents`        | <pre>ArrayList<ConcurrentHashMap<String, Object>></pre> | ArrayList containing the documents to create |
+| `documents`        | <pre>ArrayList<Map<String, Object>></pre> | ArrayList containing the documents to create |
 | `waitForRefresh`   | <pre>Boolean</pre>                                      | If set to `true`, Kuzzle will wait for the persistence layer to finish indexing |
 
 ---
@@ -47,16 +47,16 @@ Each document has the following properties:
 | Arguments          | Type                                         | Description                       |
 | ------------------ | -------------------------------------------- | --------------------------------- |
 | `_id`              | <pre>String</pre>                            | Optional document ID. Will be auto-generated if not defined.             |
-| `body`             | <pre>ConcurrentHashMap<String, Object></pre> | Document body |
+| `body`             | <pre>Map<String, Object></pre> | Document body |
 
 ## Return
 
-A `ConcurrentHashMap<String, ArrayList<Object>>` which has a `successes` and `errors` `ArrayList<Object>`:
+A `Map<String, ArrayList<Object>>` which has a `successes` and `errors` `ArrayList<Object>`:
 Each created document is an object of the `successes` array with the following properties:
 
 | Property     | Type                                         | Description                      |
 |------------- |--------------------------------------------- |--------------------------------- |
-| `_source`    | <pre>ConcurrentHashMap<String, Object></pre> | Created document                 |
+| `_source`    | <pre>Map<String, Object></pre> | Created document                 |
 | `_id`        | <pre>String</pre>                            | ID of the newly created document                       |
 | `_version`   | <pre>Integer</pre>                           | Version of the document in the persistent data storage |
 
@@ -64,7 +64,7 @@ Each errored document is an object of the `errors` array with the following prop
 
 | Property     | Type                                         | Description                      |
 |------------- |--------------------------------------------- |--------------------------------- |
-| `document`   | <pre>ConcurrentHashMap<String, Object></pre> | Document that causes the error   |
+| `document`   | <pre>Map<String, Object></pre> | Document that causes the error   |
 | `status`     | <pre>Integer</pre>                           | HTTP error status                |
 | `reason`     | <pre>String</pre>                            | Human readable reason |
 
@@ -81,15 +81,15 @@ Each errored document is an object of the `errors` array with the following prop
 fun mCreateOrReplace(
       index: String,
       collection: String,
-      documents: ArrayList<ConcurrentHashMap<String, Any?>>,
-      waitForRefresh: Boolean? = null): CompletableFuture<ConcurrentHashMap<String, ArrayList<Any>>>
+      documents: ArrayList<Map<String, Any?>>,
+      waitForRefresh: Boolean? = null): CompletableFuture<Map<String, ArrayList<Any>>>
 ```
 
 | Arguments          | Type                                                    | Description                       |
 | ------------------ | ------------------------------------------------------- | --------------------------------- |
 | `index`            | <pre>String</pre>                                       | Index                             |
 | `collection`       | <pre>String</pre>                                       | Collection                        |
-| `documents`        | <pre>ArrayList<ConcurrentHashMap<String, Any?>></pre> | ArrayList containing the documents to create |
+| `documents`        | <pre>ArrayList<Map<String, Any?>></pre> | ArrayList containing the documents to create |
 | `waitForRefresh`   | <pre>Boolean</pre>                                      | If set to `true`, Kuzzle will wait for the persistence layer to finish indexing |
 
 ---
@@ -101,16 +101,16 @@ Each document has the following properties:
 | Arguments          | Type                                         | Description                       |
 | ------------------ | -------------------------------------------- | --------------------------------- |
 | `_id`              | <pre>String</pre>                            | Optional document ID. Will be auto-generated if not defined.             |
-| `body`             | <pre>ConcurrentHashMap<String, Any?></pre> | Document body |
+| `body`             | <pre>Map<String, Any?></pre> | Document body |
 
 ## Return
 
-A `ConcurrentHashMap<String, ArrayList<Object>>` which has a `successes` and `errors` `ArrayList<Object>`:
+A `Map<String, ArrayList<Object>>` which has a `successes` and `errors` `ArrayList<Object>`:
 Each created document is an object of the `successes` array with the following properties:
 
 | Property     | Type                                         | Description                      |
 |------------- |--------------------------------------------- |--------------------------------- |
-| `_source`    | <pre>ConcurrentHashMap<String, Any?></pre> | Created document                 |
+| `_source`    | <pre>Map<String, Any?></pre> | Created document                 |
 | `_id`        | <pre>String</pre>                            | ID of the newly created document                       |
 | `_version`   | <pre>Int</pre>                           | Version of the document in the persistent data storage |
 
@@ -118,7 +118,7 @@ Each errored document is an object of the `errors` array with the following prop
 
 | Property     | Type                                         | Description                      |
 |------------- |--------------------------------------------- |--------------------------------- |
-| `document`   | <pre>ConcurrentHashMap<String, Any?></pre> | Document that causes the error   |
+| `document`   | <pre>Map<String, Any?></pre> | Document that causes the error   |
 | `status`     | <pre>Int</pre>                           | HTTP error status                |
 | `reason`     | <pre>String</pre>                            | Human readable reason |
 

--- a/doc/1/controllers/document/m-create-or-replace/snippets/m-create-or-replace-java.java
+++ b/doc/1/controllers/document/m-create-or-replace/snippets/m-create-or-replace-java.java
@@ -1,7 +1,7 @@
-ConcurrentHashMap<String, Object> document1 = new ConcurrentHashMap<>();
-ConcurrentHashMap<String, Object> document2 = new ConcurrentHashMap<>();
-ConcurrentHashMap<String, Object> body = new ConcurrentHashMap<>();
-ConcurrentHashMap<String, Object> body2 = new ConcurrentHashMap<>();
+Map<String, Object> document1 = new HashMap<>();
+Map<String, Object> document2 = new HashMap<>();
+Map<String, Object> body = new HashMap<>();
+Map<String, Object> body2 = new HashMap<>();
 
 body.put("Agent", "Smith");
 body2.put("Gordon", "Freeman");
@@ -12,11 +12,11 @@ document1.put("body", body);
 document2.put("_id", "some-id2");
 document2.put("body", body2);
 
-final ArrayList<ConcurrentHashMap<String, Object>> documents = new ArrayList<>();
+final ArrayList<Map<String, Object>> documents = new ArrayList<>();
 documents.add(document1);
 documents.add(document2);
 
-ConcurrentHashMap<String, ArrayList<Object>> result = kuzzle
+Map<String, ArrayList<Object>> result = kuzzle
   .getDocumentController()
   .mCreateOrReplace("nyc-open-data", "yellow-taxi", documents)
   .get();

--- a/doc/1/controllers/document/m-create-or-replace/snippets/m-create-or-replace-kotlin.kt
+++ b/doc/1/controllers/document/m-create-or-replace/snippets/m-create-or-replace-kotlin.kt
@@ -1,26 +1,26 @@
-val document1: ConcurrentHashMap<String, Any?> =
-    ConcurrentHashMap<String, Any?>().apply {
+val document1: Map<String, Any?> =
+    Map<String, Any?>().apply {
       put("_id", "some-id")
-      put("body", ConcurrentHashMap<String, Any?>().apply {
+      put("body", Map<String, Any?>().apply {
         put("Agent", "Smith")
       })
     }
 
-val document2: ConcurrentHashMap<String, Any?> =
-    ConcurrentHashMap<String, Any?>().apply {
+val document2: Map<String, Any?> =
+    Map<String, Any?>().apply {
       put("_id", "some-id2")
-      put("body", ConcurrentHashMap<String, Any?>().apply {
+      put("body", Map<String, Any?>().apply {
         put("Gordon", "Freeman")
       })
     }
 
-val documents: ArrayList<ConcurrentHashMap<String, Any?>> =
-    ArrayList<ConcurrentHashMap<String, Any?>>().apply {
+val documents: ArrayList<Map<String, Any?>> =
+    ArrayList<Map<String, Any?>>().apply {
       add(document1)
       add(document2)
     }
 
-val result: ConcurrentHashMap<String, ArrayList<Any>> =
+val result: Map<String, ArrayList<Any>> =
     kuzzle
         .documentController
         .mCreateOrReplace("nyc-open-data", "yellow-taxi", documents)

--- a/doc/1/controllers/document/m-create-or-replace/snippets/m-create-or-replace-kotlin.kt
+++ b/doc/1/controllers/document/m-create-or-replace/snippets/m-create-or-replace-kotlin.kt
@@ -1,15 +1,15 @@
 val document1: Map<String, Any?> =
-    Map<String, Any?>().apply {
+    HashMap<String, Any?>().apply {
       put("_id", "some-id")
-      put("body", Map<String, Any?>().apply {
+      put("body", HashMap<String, Any?>().apply {
         put("Agent", "Smith")
       })
     }
 
 val document2: Map<String, Any?> =
-    Map<String, Any?>().apply {
+    HashMap<String, Any?>().apply {
       put("_id", "some-id2")
-      put("body", Map<String, Any?>().apply {
+      put("body", HashMap<String, Any?>().apply {
         put("Gordon", "Freeman")
       })
     }

--- a/doc/1/controllers/document/m-create/index.md
+++ b/doc/1/controllers/document/m-create/index.md
@@ -17,16 +17,16 @@ Creates multiple documents.
 ## Arguments
 
 ```java
-public CompletableFuture<ConcurrentHashMap<String, ArrayList<Object>>> mCreate(
+public CompletableFuture<Map<String, ArrayList<Object>>> mCreate(
       String index,
       String collection,
-      ArrayList<ConcurrentHashMap<String, Object>> documents)
+      ArrayList<Map<String, Object>> documents)
 throws NotConnectedException, InternalException
 
-public CompletableFuture<ConcurrentHashMap<String, ArrayList<Object>>> mCreate(
+public CompletableFuture<Map<String, ArrayList<Object>>> mCreate(
       String index,
       String collection,
-      ArrayList<ConcurrentHashMap<String, Object>> documents,
+      ArrayList<Map<String, Object>> documents,
       Boolean waitForRefresh)
 throws NotConnectedException, InternalException
 ```
@@ -35,7 +35,7 @@ throws NotConnectedException, InternalException
 | ------------------ | ------------------------------------------------------- | --------------------------------- |
 | `index`            | <pre>String</pre>                                       | Index                             |
 | `collection`       | <pre>String</pre>                                       | Collection                        |
-| `documents`        | <pre>ArrayList<ConcurrentHashMap<String, Object>></pre> | ArrayList containing the documents to create |
+| `documents`        | <pre>ArrayList<Map<String, Object>></pre> | ArrayList containing the documents to create |
 | `waitForRefresh`   | <pre>Boolean</pre>                                      | If set to `true`, Kuzzle will wait for the persistence layer to finish indexing |
 
 ---
@@ -47,16 +47,16 @@ Each document has the following properties:
 | Arguments          | Type                                         | Description                       |
 | ------------------ | -------------------------------------------- | --------------------------------- |
 | `_id`              | <pre>String</pre>                            | Optional document ID. Will be auto-generated if not defined.             |
-| `body`             | <pre>ConcurrentHashMap<String, Object></pre> | Document body |
+| `body`             | <pre>Map<String, Object></pre> | Document body |
 
 ## Return
 
-A `ConcurrentHashMap<String, ArrayList<Object>>` which has a `successes` and `errors` `ArrayList<Object>`:
+A `Map<String, ArrayList<Object>>` which has a `successes` and `errors` `ArrayList<Object>`:
 Each created document is an object of the `successes` array with the following properties:
 
 | Property     | Type                                         | Description                      |
 |------------- |--------------------------------------------- |--------------------------------- |
-| `_source`    | <pre>ConcurrentHashMap<String, Object></pre> | Created document                 |
+| `_source`    | <pre>Map<String, Object></pre> | Created document                 |
 | `_id`        | <pre>String</pre>                            | ID of the newly created document                       |
 | `_version`   | <pre>Integer</pre>                           | Version of the document in the persistent data storage |
 
@@ -64,7 +64,7 @@ Each errored document is an object of the `errors` array with the following prop
 
 | Property     | Type                                         | Description                      |
 |------------- |--------------------------------------------- |--------------------------------- |
-| `document`   | <pre>ConcurrentHashMap<String, Object></pre> | Document that causes the error   |
+| `document`   | <pre>Map<String, Object></pre> | Document that causes the error   |
 | `status`     | <pre>Integer</pre>                           | HTTP error status                |
 | `reason`     | <pre>String</pre>                            | Human readable reason |
 
@@ -81,15 +81,15 @@ Each errored document is an object of the `errors` array with the following prop
 fun mCreate(
       index: String,
       collection: String,
-      documents: ArrayList<ConcurrentHashMap<String, Any?>>,
-      waitForRefresh: Boolean? = null): CompletableFuture<ConcurrentHashMap<String, ArrayList<Any>>>
+      documents: ArrayList<Map<String, Any?>>,
+      waitForRefresh: Boolean? = null): CompletableFuture<Map<String, ArrayList<Any>>>
 ```
 
 | Arguments          | Type                                                    | Description                       |
 | ------------------ | ------------------------------------------------------- | --------------------------------- |
 | `index`            | <pre>String</pre>                                       | Index                             |
 | `collection`       | <pre>String</pre>                                       | Collection                        |
-| `documents`        | <pre>ArrayList<ConcurrentHashMap<String, Any?>></pre> | ArrayList containing the documents to create |
+| `documents`        | <pre>ArrayList<Map<String, Any?>></pre> | ArrayList containing the documents to create |
 | `waitForRefresh`   | <pre>Boolean</pre>                                      | If set to `true`, Kuzzle will wait for the persistence layer to finish indexing |
 
 ---
@@ -101,16 +101,16 @@ Each document has the following properties:
 | Arguments          | Type                                         | Description                       |
 | ------------------ | -------------------------------------------- | --------------------------------- |
 | `_id`              | <pre>String</pre>                            | Optional document ID. Will be auto-generated if not defined.             |
-| `body`             | <pre>ConcurrentHashMap<String, Any?></pre> | Document body |
+| `body`             | <pre>Map<String, Any?></pre> | Document body |
 
 ## Return
 
-A `ConcurrentHashMap<String, ArrayList<Object>>` which has a `successes` and `errors` `ArrayList<Object>`:
+A `Map<String, ArrayList<Object>>` which has a `successes` and `errors` `ArrayList<Object>`:
 Each created document is an object of the `successes` array with the following properties:
 
 | Property     | Type                                         | Description                      |
 |------------- |--------------------------------------------- |--------------------------------- |
-| `_source`    | <pre>ConcurrentHashMap<String, Any?></pre> | Created document                 |
+| `_source`    | <pre>Map<String, Any?></pre> | Created document                 |
 | `_id`        | <pre>String</pre>                            | ID of the newly created document                       |
 | `_version`   | <pre>Int</pre>                           | Version of the document in the persistent data storage |
 
@@ -118,7 +118,7 @@ Each errored document is an object of the `errors` array with the following prop
 
 | Property     | Type                                         | Description                      |
 |------------- |--------------------------------------------- |--------------------------------- |
-| `document`   | <pre>ConcurrentHashMap<String, Any?></pre> | Document that causes the error   |
+| `document`   | <pre>Map<String, Any?></pre> | Document that causes the error   |
 | `status`     | <pre>Integer</pre>                           | HTTP error status                |
 | `reason`     | <pre>String</pre>                            | Human readable reason |
 

--- a/doc/1/controllers/document/m-create/snippets/m-create-java.java
+++ b/doc/1/controllers/document/m-create/snippets/m-create-java.java
@@ -1,7 +1,7 @@
-ConcurrentHashMap<String, Object> document1 = new ConcurrentHashMap<>();
-ConcurrentHashMap<String, Object> document2 = new ConcurrentHashMap<>();
-ConcurrentHashMap<String, Object> body = new ConcurrentHashMap<>();
-ConcurrentHashMap<String, Object> body2 = new ConcurrentHashMap<>();
+Map<String, Object> document1 = new HashMap<>();
+Map<String, Object> document2 = new HashMap<>();
+Map<String, Object> body = new HashMap<>();
+Map<String, Object> body2 = new HashMap<>();
 
 body.put("Agent", "Smith");
 body2.put("Gordon", "Freeman");
@@ -12,11 +12,11 @@ document1.put("body", body);
 document2.put("_id", "some-id2");
 document2.put("body", body2);
 
-final ArrayList<ConcurrentHashMap<String, Object>> documents = new ArrayList<>();
+final ArrayList<Map<String, Object>> documents = new ArrayList<>();
 documents.add(document1);
 documents.add(document2);
 
-ConcurrentHashMap<String, ArrayList<Object>> result = kuzzle
+Map<String, ArrayList<Object>> result = kuzzle
   .getDocumentController()
   .mCreate("nyc-open-data", "yellow-taxi", documents)
   .get();

--- a/doc/1/controllers/document/m-create/snippets/m-create-kotlin.kt
+++ b/doc/1/controllers/document/m-create/snippets/m-create-kotlin.kt
@@ -1,26 +1,26 @@
-val document1: ConcurrentHashMap<String, Any?> =
-    ConcurrentHashMap<String, Any?>().apply {
+val document1: Map<String, Any?> =
+    Map<String, Any?>().apply {
       put("_id", "some-id")
-      put("body", ConcurrentHashMap<String, Any?>().apply {
+      put("body", Map<String, Any?>().apply {
         put("Agent", "Smith")
       })
     }
 
-val document2: ConcurrentHashMap<String, Any?> =
-    ConcurrentHashMap<String, Any?>().apply {
+val document2: Map<String, Any?> =
+    Map<String, Any?>().apply {
       put("_id", "some-id2")
-      put("body", ConcurrentHashMap<String, Any?>().apply {
+      put("body", Map<String, Any?>().apply {
         put("Gordon", "Freeman")
       })
     }
 
-val documents: ArrayList<ConcurrentHashMap<String, Any?>> =
-    ArrayList<ConcurrentHashMap<String, Any?>>().apply {
+val documents: ArrayList<Map<String, Any?>> =
+    ArrayList<Map<String, Any?>>().apply {
       add(document1)
       add(document2)
     }
 
-val result: ConcurrentHashMap<String, ArrayList<Any>> =
+val result: Map<String, ArrayList<Any>> =
     kuzzle
         .documentController
         .mCreateOrReplace("nyc-open-data", "yellow-taxi", documents)

--- a/doc/1/controllers/document/m-create/snippets/m-create-kotlin.kt
+++ b/doc/1/controllers/document/m-create/snippets/m-create-kotlin.kt
@@ -1,15 +1,15 @@
 val document1: Map<String, Any?> =
-    Map<String, Any?>().apply {
+    HashMap<String, Any?>().apply {
       put("_id", "some-id")
-      put("body", Map<String, Any?>().apply {
+      put("body", HashMap<String, Any?>().apply {
         put("Agent", "Smith")
       })
     }
 
 val document2: Map<String, Any?> =
-    Map<String, Any?>().apply {
+    HashMap<String, Any?>().apply {
       put("_id", "some-id2")
-      put("body", Map<String, Any?>().apply {
+      put("body", HashMap<String, Any?>().apply {
         put("Gordon", "Freeman")
       })
     }

--- a/doc/1/controllers/document/m-delete/index.md
+++ b/doc/1/controllers/document/m-delete/index.md
@@ -17,13 +17,13 @@ Deletes multiple documents.
 ## Arguments 
 
 ```java
-public CompletableFuture<ConcurrentHashMap<String, ArrayList<Object>>> mDelete(
+public CompletableFuture<Map<String, ArrayList<Object>>> mDelete(
       String index,
       String collection,
       ArrayList<String> ids)
 throws NotConnectedException, InternalException
 
-public CompletableFuture<ConcurrentHashMap<String, ArrayList<Object>>> mDelete(
+public CompletableFuture<Map<String, ArrayList<Object>>> mDelete(
       String index,
       String collection,
       ArrayList<String> ids,
@@ -42,7 +42,7 @@ throws NotConnectedException, InternalException
 
 ## Return
 
-A `ConcurrentHashMap<String, ArrayList<Object>>` which has a `successes` and `errors` `ArrayList<Object>`:
+A `Map<String, ArrayList<Object>>` which has a `successes` and `errors` `ArrayList<Object>`:
 The `successes` array contains the successfully deleted document IDs.
 
 Each deletion error is an object of the errors array with the following properties:
@@ -66,7 +66,7 @@ fun mDelete(
       index: String,
       collection: String,
       ids: ArrayList<String>,
-      waitForRefresh: Boolean? = null): CompletableFuture<ConcurrentHashMap<String, ArrayList<Any>>>
+      waitForRefresh: Boolean? = null): CompletableFuture<Map<String, ArrayList<Any>>>
 ```
 
 | Arguments          | Type                                                    | Description                       |
@@ -80,7 +80,7 @@ fun mDelete(
 
 ## Return
 
-A `ConcurrentHashMap<String, ArrayList<Any>>` which has a `successes` and `errors` `ArrayList<Any>`:
+A `Map<String, ArrayList<Any>>` which has a `successes` and `errors` `ArrayList<Any>`:
 The `successes` array contains the successfully deleted document IDs.
 
 Each deletion error is an object of the errors array with the following properties:

--- a/doc/1/controllers/document/m-delete/snippets/m-delete-java.java
+++ b/doc/1/controllers/document/m-delete/snippets/m-delete-java.java
@@ -2,7 +2,7 @@ final ArrayList<String> ids = new ArrayList<>();
 ids.add("some-id");
 ids.add("some-id2");
 
-ConcurrentHashMap<String, ArrayList<Object>> result =
+Map<String, ArrayList<Object>> result =
     kuzzle
     .getDocumentController()
     .mDelete("nyc-open-data", "yellow-taxi", ids)

--- a/doc/1/controllers/document/m-delete/snippets/m-delete-kotlin.kt
+++ b/doc/1/controllers/document/m-delete/snippets/m-delete-kotlin.kt
@@ -3,7 +3,7 @@ val ids: ArrayList<String> = ArrayList<String>().apply {
     add("some-id2")
 }
 
-val result: ConcurrentHashMap<String, ArrayList<Any>> =
+val result: Map<String, ArrayList<Any>> =
     kuzzle
     .documentController
     .mDelete("nyc-open-data", "yellow-taxi", ids)

--- a/doc/1/controllers/document/m-get/index.md
+++ b/doc/1/controllers/document/m-get/index.md
@@ -17,7 +17,7 @@ Gets multiple documents.
 ## Arguments 
 
 ```java
-public CompletableFuture<ConcurrentHashMap<String, ArrayList<Object>>> mGet(
+public CompletableFuture<Map<String, ArrayList<Object>>> mGet(
       String index,
       String collection,
       ArrayList<String> ids)
@@ -34,12 +34,12 @@ throws NotConnectedException, InternalException
 
 ## Return
 
-A `ConcurrentHashMap<String, ArrayList<Object>>` which has a `successes` and `errors` `ArrayList<Object>`:
+A `Map<String, ArrayList<Object>>` which has a `successes` and `errors` `ArrayList<Object>`:
 Each created document is an object of the `successes` array with the following properties:
 
 | Property     | Type                                         | Description                      |
 |------------- |--------------------------------------------- |--------------------------------- |
-| `_source`    | <pre>ConcurrentHashMap<String, Object></pre> | Document content                 |
+| `_source`    | <pre>Map<String, Object></pre> | Document content                 |
 | `_id`        | <pre>String</pre>                            | Document ID                      |
 | `_version`   | <pre>Integer</pre>                           | Version of the document in the persistent data storage |
 
@@ -58,7 +58,7 @@ The `errors` array contain the IDs of not found documents.
 fun mGet(
       index: String,
       collection: String,
-      ids: ArrayList<String>): CompletableFuture<ConcurrentHashMap<String, ArrayList<Any>>>
+      ids: ArrayList<String>): CompletableFuture<Map<String, ArrayList<Any>>>
 ```
 
 | Arguments          | Type                                                    | Description                       |
@@ -70,12 +70,12 @@ fun mGet(
 
 ## Return
 
-A `ConcurrentHashMap<String, ArrayList<Object>>` which has a `successes` and `errors` `ArrayList<Object>`:
+A `Map<String, ArrayList<Object>>` which has a `successes` and `errors` `ArrayList<Object>`:
 Each created document is an object of the `successes` array with the following properties:
 
 | Property     | Type                                         | Description                      |
 |------------- |--------------------------------------------- |--------------------------------- |
-| `_source`    | <pre>ConcurrentHashMap<String, Any?></pre> | Document content                 |
+| `_source`    | <pre>Map<String, Any?></pre> | Document content                 |
 | `_id`        | <pre>String</pre>                            | Document ID                      |
 | `_version`   | <pre>Int</pre>                           | Version of the document in the persistent data storage |
 

--- a/doc/1/controllers/document/m-get/snippets/m-get-java.java
+++ b/doc/1/controllers/document/m-get/snippets/m-get-java.java
@@ -2,7 +2,7 @@ final ArrayList<String> ids = new ArrayList<>();
 ids.add("some-id");
 ids.add("some-id2");
 
-ConcurrentHashMap<String, ArrayList<Object>> result =
+Map<String, ArrayList<Object>> result =
     kuzzle
     .getDocumentController()
     .mGet("nyc-open-data", "yellow-taxi", ids)

--- a/doc/1/controllers/document/m-get/snippets/m-get-kotlin.kt
+++ b/doc/1/controllers/document/m-get/snippets/m-get-kotlin.kt
@@ -3,7 +3,7 @@ val ids: ArrayList<String> = ArrayList<String>().apply {
     add("some-id2")
 }
 
-val result: ConcurrentHashMap<String, ArrayList<Any>> =
+val result: Map<String, ArrayList<Any>> =
     kuzzle
     .documentController
     .mGet("nyc-open-data", "yellow-taxi", ids)

--- a/doc/1/controllers/document/m-replace/index.md
+++ b/doc/1/controllers/document/m-replace/index.md
@@ -17,16 +17,16 @@ Replaces multiple documents.
 ## Arguments
 
 ```java
-public CompletableFuture<ConcurrentHashMap<String, ArrayList<Object>>> mReplace(
+public CompletableFuture<Map<String, ArrayList<Object>>> mReplace(
       String index,
       String collection,
-      ArrayList<ConcurrentHashMap<String, Object>> documents)
+      ArrayList<Map<String, Object>> documents)
 throws NotConnectedException, InternalException
 
-public CompletableFuture<ConcurrentHashMap<String, ArrayList<Object>>> mReplace(
+public CompletableFuture<Map<String, ArrayList<Object>>> mReplace(
       String index,
       String collection,
-      ArrayList<ConcurrentHashMap<String, Object>> documents,
+      ArrayList<Map<String, Object>> documents,
       Boolean waitForRefresh)
 throws NotConnectedException, InternalException
 ```
@@ -35,7 +35,7 @@ throws NotConnectedException, InternalException
 | ------------------ | ------------------------------------------------------- | --------------------------------- |
 | `index`            | <pre>String</pre>                                       | Index                             |
 | `collection`       | <pre>String</pre>                                       | Collection                        |
-| `documents`        | <pre>ArrayList<ConcurrentHashMap<String, Object>></pre> | ArrayList containing the documents to replace |
+| `documents`        | <pre>ArrayList<Map<String, Object>></pre> | ArrayList containing the documents to replace |
 | `waitForRefresh`   | <pre>Boolean</pre>                                      | If set to `true`, Kuzzle will wait for the persistence layer to finish indexing |
 
 ---
@@ -47,16 +47,16 @@ Each document has the following properties:
 | Arguments          | Type                                         | Description                       |
 | ------------------ | -------------------------------------------- | --------------------------------- |
 | `_id`              | <pre>String</pre>                            | Optional document ID. Will be auto-generated if not defined.             |
-| `body`             | <pre>ConcurrentHashMap<String, Object></pre> | Document body |
+| `body`             | <pre>Map<String, Object></pre> | Document body |
 
 ## Return
 
-A `ConcurrentHashMap<String, ArrayList<Object>>` which has a `successes` and `errors` `ArrayList<Object>`:
+A `Map<String, ArrayList<Object>>` which has a `successes` and `errors` `ArrayList<Object>`:
 Each created document is an object of the `successes` array with the following properties:
 
 | Property     | Type                                         | Description                      |
 |------------- |--------------------------------------------- |--------------------------------- |
-| `_source`    | <pre>ConcurrentHashMap<String, Object></pre> | Created document                 |
+| `_source`    | <pre>Map<String, Object></pre> | Created document                 |
 | `_id`        | <pre>String</pre>                            | ID of the replaced document      |
 | `_version`   | <pre>Integer</pre>                           | Version of the document in the persistent data storage |
 
@@ -64,7 +64,7 @@ Each errored document is an object of the `errors` array with the following prop
 
 | Property     | Type                                         | Description                      |
 |------------- |--------------------------------------------- |--------------------------------- |
-| `document`   | <pre>ConcurrentHashMap<String, Object></pre> | Document that causes the error   |
+| `document`   | <pre>Map<String, Object></pre> | Document that causes the error   |
 | `status`     | <pre>Integer</pre>                           | HTTP error status                |
 | `reason`     | <pre>String</pre>                            | Human readable reason |
 
@@ -81,15 +81,15 @@ Each errored document is an object of the `errors` array with the following prop
 fun mReplace(
       index: String,
       collection: String,
-      documents: ArrayList<ConcurrentHashMap<String, Any?>>,
-      waitForRefresh: Boolean? = null): CompletableFuture<ConcurrentHashMap<String, ArrayList<Any>?>>
+      documents: ArrayList<Map<String, Any?>>,
+      waitForRefresh: Boolean? = null): CompletableFuture<Map<String, ArrayList<Any>?>>
 ```
 
 | Arguments          | Type                                                    | Description                       |
 | ------------------ | ------------------------------------------------------- | --------------------------------- |
 | `index`            | <pre>String</pre>                                       | Index                             |
 | `collection`       | <pre>String</pre>                                       | Collection                        |
-| `documents`        | <pre>ArrayList<ConcurrentHashMap<String, Any?>></pre> | ArrayList containing the documents to replace |
+| `documents`        | <pre>ArrayList<Map<String, Any?>></pre> | ArrayList containing the documents to replace |
 | `waitForRefresh`   | <pre>Boolean</pre>                                      | If set to `true`, Kuzzle will wait for the persistence layer to finish indexing |
 
 ---
@@ -101,16 +101,16 @@ Each document has the following properties:
 | Arguments          | Type                                         | Description                       |
 | ------------------ | -------------------------------------------- | --------------------------------- |
 | `_id`              | <pre>String</pre>                            | Optional document ID. Will be auto-generated if not defined.             |
-| `body`             | <pre>ConcurrentHashMap<String, Any?></pre> | Document body |
+| `body`             | <pre>Map<String, Any?></pre> | Document body |
 
 ## Return
 
-A `ConcurrentHashMap<String, ArrayList<Any?>>` which has a `successes` and `errors` `ArrayList<Any?>`:
+A `Map<String, ArrayList<Any?>>` which has a `successes` and `errors` `ArrayList<Any?>`:
 Each created document is an object of the `successes` array with the following properties:
 
 | Property     | Type                                         | Description                      |
 |------------- |--------------------------------------------- |--------------------------------- |
-| `_source`    | <pre>ConcurrentHashMap<String, Any?></pre> | Created document                 |
+| `_source`    | <pre>Map<String, Any?></pre> | Created document                 |
 | `_id`        | <pre>String</pre>                            | ID of the replaced document      |
 | `_version`   | <pre>Int</pre>                           | Version of the document in the persistent data storage |
 
@@ -118,7 +118,7 @@ Each errored document is an object of the `errors` array with the following prop
 
 | Property     | Type                                         | Description                      |
 |------------- |--------------------------------------------- |--------------------------------- |
-| `document`   | <pre>ConcurrentHashMap<String, Any?></pre> | Document that causes the error   |
+| `document`   | <pre>Map<String, Any?></pre> | Document that causes the error   |
 | `status`     | <pre>Int</pre>                           | HTTP error status                |
 | `reason`     | <pre>String</pre>                            | Human readable reason |
 

--- a/doc/1/controllers/document/m-replace/snippets/m-replace-java.java
+++ b/doc/1/controllers/document/m-replace/snippets/m-replace-java.java
@@ -1,7 +1,7 @@
-ConcurrentHashMap<String, Object> document1 = new ConcurrentHashMap<>();
-ConcurrentHashMap<String, Object> document2 = new ConcurrentHashMap<>();
-ConcurrentHashMap<String, Object> body = new ConcurrentHashMap<>();
-ConcurrentHashMap<String, Object> body2 = new ConcurrentHashMap<>();
+Map<String, Object> document1 = new HashMap<>();
+Map<String, Object> document2 = new HashMap<>();
+Map<String, Object> body = new HashMap<>();
+Map<String, Object> body2 = new HashMap<>();
 
 body.put("name", "Smith");
 body2.put("name", "Freeman");
@@ -12,11 +12,11 @@ document1.put("body", body);
 document2.put("_id", "some-id2");
 document2.put("body", body2);
 
-final ArrayList<ConcurrentHashMap<String, Object>> documents = new ArrayList<>();
+final ArrayList<Map<String, Object>> documents = new ArrayList<>();
 documents.add(document1);
 documents.add(document2);
 
-ConcurrentHashMap<String, ArrayList<Object>> result = kuzzle
+Map<String, ArrayList<Object>> result = kuzzle
   .getDocumentController()
   .mReplace("nyc-open-data", "yellow-taxi", documents)
   .get();

--- a/doc/1/controllers/document/m-replace/snippets/m-replace-kotlin.kt
+++ b/doc/1/controllers/document/m-replace/snippets/m-replace-kotlin.kt
@@ -1,15 +1,15 @@
 val document1: Map<String, Any?> =
-  Map<String, Any?>().apply {
+  HashMap<String, Any?>().apply {
     put("_id", "some-id")
-    put("body", Map<String, Any?>().apply {
+    put("body", HashMap<String, Any?>().apply {
       put("name", "Smith")
     })
   }
 
 val document2: Map<String, Any?> =
-  Map<String, Any?>().apply {
+  HashMap<String, Any?>().apply {
     put("_id", "some-id2")
-    put("body", Map<String, Any?>().apply {
+    put("body", HashMap<String, Any?>().apply {
       put("name", "Freeman")
     })
   }

--- a/doc/1/controllers/document/m-replace/snippets/m-replace-kotlin.kt
+++ b/doc/1/controllers/document/m-replace/snippets/m-replace-kotlin.kt
@@ -1,27 +1,27 @@
-val document1: ConcurrentHashMap<String, Any?> = 
-  ConcurrentHashMap<String, Any?>().apply {
+val document1: Map<String, Any?> =
+  Map<String, Any?>().apply {
     put("_id", "some-id")
-    put("body", ConcurrentHashMap<String, Any?>().apply {
+    put("body", Map<String, Any?>().apply {
       put("name", "Smith")
     })
   }
 
-val document2: ConcurrentHashMap<String, Any?> = 
-  ConcurrentHashMap<String, Any?>().apply {
+val document2: Map<String, Any?> =
+  Map<String, Any?>().apply {
     put("_id", "some-id2")
-    put("body", ConcurrentHashMap<String, Any?>().apply {
+    put("body", Map<String, Any?>().apply {
       put("name", "Freeman")
     })
   }
 
-val documents: ArrayList<ConcurrentHashMap<String, Any?>> =
-    ArrayList<ConcurrentHashMap<String, Any?>>().apply {
+val documents: ArrayList<Map<String, Any?>> =
+    ArrayList<Map<String, Any?>>().apply {
       add(document1)
       add(document2)
     }
 
 
-val result: ConcurrentHashMap<String, ArrayList<Any>?> =
+val result: Map<String, ArrayList<Any>?> =
   kuzzle
   .documentController
   .mReplace("nyc-open-data", "yellow-taxi", documents)

--- a/doc/1/controllers/document/m-update/index.md
+++ b/doc/1/controllers/document/m-update/index.md
@@ -17,16 +17,16 @@ Updates multiple documents.
 ## Arguments
 
 ```java
-public CompletableFuture<ConcurrentHashMap<String, ArrayList<Object>>> mUpdate(
+public CompletableFuture<Map<String, ArrayList<Object>>> mUpdate(
       String index,
       String collection,
-      ArrayList<ConcurrentHashMap<String, Object>> documents)
+      ArrayList<Map<String, Object>> documents)
 throws NotConnectedException, InternalException
 
-public CompletableFuture<ConcurrentHashMap<String, ArrayList<Object>>> mUpdate(
+public CompletableFuture<Map<String, ArrayList<Object>>> mUpdate(
       String index,
       String collection,
-      ArrayList<ConcurrentHashMap<String, Object>> documents,
+      ArrayList<Map<String, Object>> documents,
       UpdateOptions options)
 throws NotConnectedException, InternalException
 ```
@@ -35,7 +35,7 @@ throws NotConnectedException, InternalException
 | ------------------ | ------------------------------------------------------- | --------------------------------- |
 | `index`            | <pre>String</pre>                                       | Index                             |
 | `collection`       | <pre>String</pre>                                       | Collection                        |
-| `documents`        | <pre>ArrayList<ConcurrentHashMap<String, Object>></pre> | ArrayList containing the documents to update |
+| `documents`        | <pre>ArrayList<Map<String, Object>></pre> | ArrayList containing the documents to update |
 | `retryOnConflict`  | <pre>Integer</pre> (optional)                | The number of times the database layer should retry in case of version conflict |
 | `waitForRefresh`   | <pre>Boolean</pre> (optional)                | If set to `true`, Kuzzle will wait for the persistence layer to finish indexing |
 
@@ -48,17 +48,17 @@ Each document has the following properties:
 | Arguments          | Type                                         | Description                       |
 | ------------------ | -------------------------------------------- | --------------------------------- |
 | `_id`              | <pre>String</pre>                            | Document ID             |
-| `body`             | <pre>ConcurrentHashMap<String, Object></pre> | Document body |
+| `body`             | <pre>Map<String, Object></pre> | Document body |
 
 
 ## Return
 
-A `ConcurrentHashMap<String, ArrayList<Object>>` which has a `successes` and `errors` `ArrayList<Object>`:
+A `Map<String, ArrayList<Object>>` which has a `successes` and `errors` `ArrayList<Object>`:
 Each created document is an object of the `successes` array with the following properties:
 
 | Property     | Type                                         | Description                      |
 |------------- |--------------------------------------------- |--------------------------------- |
-| `_source`    | <pre>ConcurrentHashMap<String, Object></pre> | Updated document                 |
+| `_source`    | <pre>Map<String, Object></pre> | Updated document                 |
 | `_id`        | <pre>String</pre>                            | ID of the updated document       |
 | `_version`   | <pre>Integer</pre>                           | Version of the document in the persistent data storage |
 
@@ -66,7 +66,7 @@ Each errored document is an object of the `errors` array with the following prop
 
 | Property     | Type                                         | Description                      |
 |------------- |--------------------------------------------- |--------------------------------- |
-| `document`   | <pre>ConcurrentHashMap<String, Object></pre> | Document that causes the error   |
+| `document`   | <pre>Map<String, Object></pre> | Document that causes the error   |
 | `status`     | <pre>Integer</pre>                           | HTTP error status                |
 | `reason`     | <pre>String</pre>                            | Human readable reason |
 
@@ -84,16 +84,16 @@ Each errored document is an object of the `errors` array with the following prop
   fun mUpdate(
       index: String,
       collection: String,
-      documents: ArrayList<ConcurrentHashMap<String, Any?>?>,
+      documents: ArrayList<Map<String, Any?>?>,
       waitForRefresh: Boolean? = null,
-      retryOnConflict: Int? = null): CompletableFuture<ConcurrentHashMap<String, ArrayList<Any>?>>
+      retryOnConflict: Int? = null): CompletableFuture<Map<String, ArrayList<Any>?>>
 ```
 
 | Arguments          | Type                                                    | Description                       |
 | ------------------ | ------------------------------------------------------- | --------------------------------- |
 | `index`            | <pre>String</pre>                                       | Index                             |
 | `collection`       | <pre>String</pre>                                       | Collection                        |
-| `documents`        | <pre>ArrayList<ConcurrentHashMap<String, Any?>></pre> | ArrayList containing the documents to update |
+| `documents`        | <pre>ArrayList<Map<String, Any?>></pre> | ArrayList containing the documents to update |
 | `retryOnConflict`  | <pre>Int</pre> (optional)                | The number of times the database layer should retry in case of version conflict |
 | `waitForRefresh`   | <pre>Boolean</pre> (optional)                | If set to `true`, Kuzzle will wait for the persistence layer to finish indexing |
 
@@ -106,17 +106,17 @@ Each document has the following properties:
 | Arguments          | Type                                         | Description                       |
 | ------------------ | -------------------------------------------- | --------------------------------- |
 | `_id`              | <pre>String</pre>                            | Document ID             |
-| `body`             | <pre>ConcurrentHashMap<String, Any?></pre> | Document body |
+| `body`             | <pre>Map<String, Any?></pre> | Document body |
 
 
 ## Return
 
-A `ConcurrentHashMap<String, ArrayList<Any?>>` which has a `successes` and `errors` `ArrayList<Any?>`:
+A `Map<String, ArrayList<Any?>>` which has a `successes` and `errors` `ArrayList<Any?>`:
 Each created document is an object of the `successes` array with the following properties:
 
 | Property     | Type                                         | Description                      |
 |------------- |--------------------------------------------- |--------------------------------- |
-| `_source`    | <pre>ConcurrentHashMap<String, Any?></pre> | Updated document                 |
+| `_source`    | <pre>Map<String, Any?></pre> | Updated document                 |
 | `_id`        | <pre>String</pre>                            | ID of the updated document       |
 | `_version`   | <pre>Int</pre>                           | Version of the document in the persistent data storage |
 
@@ -124,7 +124,7 @@ Each errored document is an object of the `errors` array with the following prop
 
 | Property     | Type                                         | Description                      |
 |------------- |--------------------------------------------- |--------------------------------- |
-| `document`   | <pre>ConcurrentHashMap<String, Any?></pre> | Document that causes the error   |
+| `document`   | <pre>Map<String, Any?></pre> | Document that causes the error   |
 | `status`     | <pre>Int</pre>                           | HTTP error status                |
 | `reason`     | <pre>String</pre>                            | Human readable reason |
 

--- a/doc/1/controllers/document/m-update/snippets/m-update-java.java
+++ b/doc/1/controllers/document/m-update/snippets/m-update-java.java
@@ -1,7 +1,7 @@
-ConcurrentHashMap<String, Object> document1 = new ConcurrentHashMap<>();
-ConcurrentHashMap<String, Object> document2 = new ConcurrentHashMap<>();
-ConcurrentHashMap<String, Object> body = new ConcurrentHashMap<>();
-ConcurrentHashMap<String, Object> body2 = new ConcurrentHashMap<>();
+Map<String, Object> document1 = new HashMap<>();
+Map<String, Object> document2 = new HashMap<>();
+Map<String, Object> body = new HashMap<>();
+Map<String, Object> body2 = new HashMap<>();
 
 body.put("name", "Smith");
 body2.put("name", "Freeman");
@@ -12,11 +12,11 @@ document1.put("body", body);
 document2.put("_id", "some-id2");
 document2.put("body", body2);
 
-final ArrayList<ConcurrentHashMap<String, Object>> documents = new ArrayList<>();
+final ArrayList<Map<String, Object>> documents = new ArrayList<>();
 documents.add(document1);
 documents.add(document2);
 
-ConcurrentHashMap<String, ArrayList<Object>> result = kuzzle
+Map<String, ArrayList<Object>> result = kuzzle
   .getDocumentController()
   .mUpdate("nyc-open-data", "yellow-taxi", documents)
   .get();

--- a/doc/1/controllers/document/m-update/snippets/m-update-kotlin.kt
+++ b/doc/1/controllers/document/m-update/snippets/m-update-kotlin.kt
@@ -1,27 +1,27 @@
-val document1: ConcurrentHashMap<String, Any?> = 
-  ConcurrentHashMap<String, Any?>().apply {
+val document1: Map<String, Any?> = 
+  Map<String, Any?>().apply {
     put("_id", "some-id")
-    put("body", ConcurrentHashMap<String, Any?>().apply {
+    put("body", Map<String, Any?>().apply {
       put("name", "Smith")
     })
   }
 
-val document2: ConcurrentHashMap<String, Any?> = 
-  ConcurrentHashMap<String, Any?>().apply {
+val document2: Map<String, Any?> = 
+  Map<String, Any?>().apply {
     put("_id", "some-id2")
-    put("body", ConcurrentHashMap<String, Any?>().apply {
+    put("body", Map<String, Any?>().apply {
       put("name", "Freeman")
     })
   }
 
-val documents: ArrayList<ConcurrentHashMap<String, Any?>> =
-    ArrayList<ConcurrentHashMap<String, Any?>>().apply {
+val documents: ArrayList<Map<String, Any?>> =
+    ArrayList<Map<String, Any?>>().apply {
       add(document1)
       add(document2)
     }
 
 
-val result: ConcurrentHashMap<String, ArrayList<Any>?> =
+val result: Map<String, ArrayList<Any>?> =
   kuzzle
   .documentController
   .mReplace("nyc-open-data", "yellow-taxi", documents)

--- a/doc/1/controllers/document/m-update/snippets/m-update-kotlin.kt
+++ b/doc/1/controllers/document/m-update/snippets/m-update-kotlin.kt
@@ -1,15 +1,15 @@
 val document1: Map<String, Any?> = 
-  Map<String, Any?>().apply {
+  HashMap<String, Any?>().apply {
     put("_id", "some-id")
-    put("body", Map<String, Any?>().apply {
+    put("body", HashMap<String, Any?>().apply {
       put("name", "Smith")
     })
   }
 
 val document2: Map<String, Any?> = 
-  Map<String, Any?>().apply {
+  HashMap<String, Any?>().apply {
     put("_id", "some-id2")
-    put("body", Map<String, Any?>().apply {
+    put("body", HashMap<String, Any?>().apply {
       put("name", "Freeman")
     })
   }

--- a/doc/1/controllers/document/replace/index.md
+++ b/doc/1/controllers/document/replace/index.md
@@ -17,18 +17,18 @@ Replaces the content of an existing document.
 ## Arguments
 
 ```java
-public CompletableFuture<ConcurrentHashMap<String, Object>> replace(
+public CompletableFuture<Map<String, Object>> replace(
       String index,
       String collection,
       String id,
-      ConcurrentHashMap<String, Object> document)
+      Map<String, Object> document)
 throws NotConnectedException, InternalException
 
-public CompletableFuture<ConcurrentHashMap<String, Object>> replace(
+public CompletableFuture<Map<String, Object>> replace(
       String index,
       String collection,
       String id,
-      ConcurrentHashMap<String, Object> document,
+      Map<String, Object> document,
       Boolean waitForRefresh)
 throws NotConnectedException, InternalException
 ```
@@ -38,18 +38,18 @@ throws NotConnectedException, InternalException
 | `index`            | <pre>String</pre>                            | Index                             |
 | `collection`       | <pre>String</pre>                            | Collection                        |
 | `id`               | <pre>String</pre>                            | Document ID                       |
-| `document`         | <pre>ConcurrentHashMap<String, Object></pre> | New content of the document to update |
+| `document`         | <pre>Map<String, Object></pre> | New content of the document to update |
 | `waitForRefresh`   | <pre>Boolean</pre>                           | If set to `true`, Kuzzle will wait for the persistence layer to finish indexing|
 
 ---
 
 ## Return
 
-A `ConcurrentHashMap` which has the following properties:
+A `Map` which has the following properties:
 
 | Property     | Type                         | Description                      |
 |------------- |----------------------------- |--------------------------------- |
-| `_source`    | <pre>ConcurrentHashMap</pre> | Document content                 |
+| `_source`    | <pre>Map</pre> | Document content                 |
 | `_id`        | <pre>String</pre>            | ID of the document                       |
 | `_version`   | <pre>Integer</pre>           | Version of the document in the persistent data storage |
 
@@ -67,8 +67,8 @@ fun replace(
       index: String,
       collection: String,
       id: String?,
-      document: ConcurrentHashMap<String, Any?>,
-      waitForRefresh: Boolean? = null): CompletableFuture<ConcurrentHashMap<String, Any?>>
+      document: Map<String, Any?>,
+      waitForRefresh: Boolean? = null): CompletableFuture<Map<String, Any?>>
 ```
 
 | Arguments          | Type                                         | Description                       |
@@ -76,18 +76,18 @@ fun replace(
 | `index`            | <pre>String</pre>                            | Index                             |
 | `collection`       | <pre>String</pre>                            | Collection                        |
 | `id`               | <pre>String</pre>                            | Document ID                       |
-| `document`         | <pre>ConcurrentHashMap<String, Any?></pre> | New content of the document to update |
+| `document`         | <pre>Map<String, Any?></pre> | New content of the document to update |
 | `waitForRefresh`   | <pre>Boolean</pre>                           | If set to `true`, Kuzzle will wait for the persistence layer to finish indexing|
 
 ---
 
 ## Return
 
-A `ConcurrentHashMap` which has the following properties:
+A `Map` which has the following properties:
 
 | Property     | Type                         | Description                      |
 |------------- |----------------------------- |--------------------------------- |
-| `_source`    | <pre>ConcurrentHashMap</pre> | Document content                 |
+| `_source`    | <pre>Map</pre> | Document content                 |
 | `_id`        | <pre>String</pre>            | ID of the document                       |
 | `_version`   | <pre>Int</pre>           | Version of the document in the persistent data storage |
 

--- a/doc/1/controllers/document/replace/snippets/replace-java.java
+++ b/doc/1/controllers/document/replace/snippets/replace-java.java
@@ -1,8 +1,8 @@
 
-  ConcurrentHashMap<String, Object> document = new ConcurrentHashMap<>();
+  Map<String, Object> document = new HashMap<>();
   document.put("firstname", "John");
 
-  ConcurrentHashMap<String, Object> result = kuzzle.getDocumentController().replace("nyc-open-data", "yellow-taxi", "some-id", document)
+  Map<String, Object> result = kuzzle.getDocumentController().replace("nyc-open-data", "yellow-taxi", "some-id", document)
   .get();
 
   /*

--- a/doc/1/controllers/document/replace/snippets/replace-kotlin.kt
+++ b/doc/1/controllers/document/replace/snippets/replace-kotlin.kt
@@ -1,5 +1,5 @@
 val document: Map<String, Any?> =
-  Map<String, Any?>().apply {
+  HashMap<String, Any?>().apply {
     put("firstname", "John")
   }
 

--- a/doc/1/controllers/document/replace/snippets/replace-kotlin.kt
+++ b/doc/1/controllers/document/replace/snippets/replace-kotlin.kt
@@ -1,9 +1,9 @@
-val document: ConcurrentHashMap<String, Any?> =
-  ConcurrentHashMap<String, Any?>().apply {
+val document: Map<String, Any?> =
+  Map<String, Any?>().apply {
     put("firstname", "John")
   }
 
-val result: ConcurrentHashMap<String, Any?> =
+val result: Map<String, Any?> =
   kuzzle
   .documentController
   .replace("nyc-open-data", "yellow-taxi", "some-id", document)

--- a/doc/1/controllers/document/search/index.md
+++ b/doc/1/controllers/document/search/index.md
@@ -39,25 +39,25 @@ You can restrict the scroll session maximum duration under the `services.storage
 public CompletableFuture<SearchResult> search(
       String index,
       String collection,
-      ConcurrentHashMap<String, Object> searchQuery) throws NotConnectedException, InternalException
+      Map<String, Object> searchQuery) throws NotConnectedException, InternalException
 
 public CompletableFuture<SearchResult> search(
       String index,
       String collection,
-      ConcurrentHashMap<String, Object> searchQuery,
+      Map<String, Object> searchQuery,
       String scroll) throws NotConnectedException, InternalException
 
 public CompletableFuture<SearchResult> search(
       String index,
       String collection,
-      ConcurrentHashMap<String, Object> searchQuery,
+      Map<String, Object> searchQuery,
       String scroll,
       Integer size) throws NotConnectedException, InternalException
 
 public CompletableFuture<SearchResult> search(
       String index,
       String collection,
-      ConcurrentHashMap<String, Object> searchQuery
+      Map<String, Object> searchQuery
       Integer size,
       Integer from)
 throws NotConnectedException, InternalException
@@ -67,7 +67,7 @@ throws NotConnectedException, InternalException
 | ------------------ | -------------------------------------------- | --------------------------------- |
 | `index`            | <pre>String</pre>                            | Index                             |
 | `collection`       | <pre>String</pre>                            | Collection                        |
-| `searchQuery`      | <pre>ConcurrentHashMap</pre>                 | Search query                      |
+| `searchQuery`      | <pre>Map</pre>                 | Search query                      |
 | `from`     | <pre>Integer</pre><br/>(`0`)    | Offset of the first document to fetch                                                                                                                                                                             |
 | `size`     | <pre>Integer</pre><br/>(`10`)   | Maximum number of documents to retrieve per page                                                                                                                                                                  |
 | `scroll`   | <pre>String</pre><br/>(`""`)    | When set, gets a forward-only cursor having its ttl set to the given value (ie `1s`; cf [elasticsearch time limits](https://www.elastic.co/guide/en/elasticsearch/reference/7.3/common-options.html#time-units)) |
@@ -99,7 +99,7 @@ Returns a [SearchResult](/sdk/jvm/1/core-classes/search-result) object.
   fun search(
       index: String,
       collection: String,
-      searchQuery: ConcurrentHashMap<String?, Any?>,
+      searchQuery: Map<String?, Any?>,
       scroll: String? = null,
       size: Int? = null,
       from: Int = 0): CompletableFuture<SearchResult>
@@ -109,7 +109,7 @@ Returns a [SearchResult](/sdk/jvm/1/core-classes/search-result) object.
 | ------------------ | -------------------------------------------- | --------------------------------- |
 | `index`            | <pre>String</pre>                            | Index                             |
 | `collection`       | <pre>String</pre>                            | Collection                        |
-| `searchQuery`      | <pre>ConcurrentHashMap</pre>                 | Search query                      |
+| `searchQuery`      | <pre>Map</pre>                 | Search query                      |
 | `from`     | <pre>Int</pre><br/>(`0`)    | Offset of the first document to fetch                                                                                                                                                                             |
 | `size`     | <pre>Int</pre><br/>(`10`)   | Maximum number of documents to retrieve per page                                                                                                                                                                  |
 | `scroll`   | <pre>String</pre><br/>(`""`)    | When set, gets a forward-only cursor having its ttl set to the given value (ie `1s`; cf [elasticsearch time limits](https://www.elastic.co/guide/en/elasticsearch/reference/7.3/common-options.html#time-units)) |

--- a/doc/1/controllers/document/search/snippets/search-java.java
+++ b/doc/1/controllers/document/search/snippets/search-java.java
@@ -1,6 +1,6 @@
-    ConcurrentHashMap<String, Object> searchQuery = new ConcurrentHashMap<>();
-    ConcurrentHashMap<String, Object> query = new ConcurrentHashMap<>();
-    ConcurrentHashMap<String, Object> match = new ConcurrentHashMap<>();
+    Map<String, Object> searchQuery = new HashMap<>();
+    Map<String, Object> query = new HashMap<>();
+    Map<String, Object> match = new HashMap<>();
     match.put("category", "suv");
     query.put("match", match);
     searchQuery.put("query", query);

--- a/doc/1/controllers/document/search/snippets/search-kotlin.kt
+++ b/doc/1/controllers/document/search/snippets/search-kotlin.kt
@@ -1,14 +1,14 @@
 val match: Map<String, Any?> =
-  Map<String, Any?>().apply {
+  HashMap<String, Any?>().apply {
     put("category", "suv")
   }
 val query: Map<String, Any?> =
-  Map<String, Any?>().apply {
+  HashMap<String, Any?>().apply {
     put("match", match)
   }
 
 val searchQuery: Map<String, Any?> =
-  Map<String, Any?>().apply {
+  HashMap<String, Any?>().apply {
     put("query", query)
   }
 val results = kuzzle

--- a/doc/1/controllers/document/search/snippets/search-kotlin.kt
+++ b/doc/1/controllers/document/search/snippets/search-kotlin.kt
@@ -1,14 +1,14 @@
-val match: ConcurrentHashMap<String, Any?> =
-  ConcurrentHashMap<String, Any?>().apply {
+val match: Map<String, Any?> =
+  Map<String, Any?>().apply {
     put("category", "suv")
   }
-val query: ConcurrentHashMap<String, Any?> =
-  ConcurrentHashMap<String, Any?>().apply {
+val query: Map<String, Any?> =
+  Map<String, Any?>().apply {
     put("match", match)
   }
 
-val searchQuery: ConcurrentHashMap<String, Any?> =
-  ConcurrentHashMap<String, Any?>().apply {
+val searchQuery: Map<String, Any?> =
+  Map<String, Any?>().apply {
     put("query", query)
   }
 val results = kuzzle

--- a/doc/1/controllers/document/update-by-query/index.md
+++ b/doc/1/controllers/document/update-by-query/index.md
@@ -20,17 +20,17 @@ An empty or null query will match all documents in the collection.
 
 
 ```java
-  public CompletableFuture<ConcurrentHashMap<String, ArrayList<Object>>> updateByQuery(
+  public CompletableFuture<Map<String, ArrayList<Object>>> updateByQuery(
       String index,
       String collection,
-      ConcurrentHashMap<String, Object> searchQuery,
-      ConcurrentHashMap<String, Object> changes) throws NotConnectedException, InternalException
+      Map<String, Object> searchQuery,
+      Map<String, Object> changes) throws NotConnectedException, InternalException
 
-  public CompletableFuture<ConcurrentHashMap<String, ArrayList<Object>>> updateByQuery(
+  public CompletableFuture<Map<String, ArrayList<Object>>> updateByQuery(
       String index,
       String collection,
-      ConcurrentHashMap<String, Object> searchQuery,
-      ConcurrentHashMap<String, Object> changes,
+      Map<String, Object> searchQuery,
+      Map<String, Object> changes,
       UpdateOptions options) throws NotConnectedException, InternalException
 ```
 
@@ -38,8 +38,8 @@ An empty or null query will match all documents in the collection.
 | ------------------ | -------------------------------------------- | --------------- |
 | `index`            | <pre>String</pre>                            | Index name      |
 | `collection`       | <pre>String</pre>                            | Collection name |
-| `searchQuery`      | <pre>ConcurrentHashMap<String, Object></pre> | Query to match  |
-| `changes`          | <pre>ConcurrentHashMap<String, Object></pre> | Partial changes to apply to the documents |
+| `searchQuery`      | <pre>Map<String, Object></pre> | Query to match  |
+| `changes`          | <pre>Map<String, Object></pre> | Partial changes to apply to the documents |
 | `waitForRefresh`   | <pre>Boolean</pre>                           | If set to `true`, Kuzzle will wait for the persistence layer to finish indexing|
 | `source`           | <pre>Boolean</pre>                           | If true, returns the updated document inside the response |
 
@@ -47,12 +47,12 @@ An empty or null query will match all documents in the collection.
 
 ## Returns
 
-A `ConcurrentHashMap<String, ArrayList<Object>>` which has a `successes` and `errors` `ArrayList<Object>`:
+A `Map<String, ArrayList<Object>>` which has a `successes` and `errors` `ArrayList<Object>`:
 Each updated document is an object of the `successes` array with the following properties:
 
 | Property     | Type                                         | Description                      |
 |------------- |--------------------------------------------- |--------------------------------- |
-| `_source`    | <pre>ConcurrentHashMap<String, Object></pre> | Updated document (if `source` option set to true)  |
+| `_source`    | <pre>Map<String, Object></pre> | Updated document (if `source` option set to true)  |
 | `_id`        | <pre>String</pre>                            | ID of the udated document                   |
 | `_version`   | <pre>Integer</pre>                           | Version of the document in the persistent data storage |
 | `status`     | <pre>Integer</pre>                           | HTTP status code |
@@ -61,7 +61,7 @@ Each errored document is an object of the `errors` array with the following prop
 
 | Property     | Type                                         | Description                      |
 |------------- |--------------------------------------------- |--------------------------------- |
-| `document`   | <pre>ConcurrentHashMap<String, Object></pre> | Document that causes the error   |
+| `document`   | <pre>Map<String, Object></pre> | Document that causes the error   |
 | `status`     | <pre>Integer</pre>                           | HTTP error status                |
 | `reason`     | <pre>String</pre>                            | Human readable reason |
 
@@ -76,19 +76,19 @@ Each errored document is an object of the `errors` array with the following prop
 fun updateByQuery(
       index: String,
       collection: String,
-      searchQuery: ConcurrentHashMap<String, Any?>,
-      changes: ConcurrentHashMap<String, Any?>,
+      searchQuery: Map<String, Any?>,
+      changes: Map<String, Any?>,
       waitForRefresh: Boolean? = null,
       retryOnConflict: Int? = null,
-      source: Boolean? = null): CompletableFuture<ConcurrentHashMap<String, ArrayList<Any?>>>
+      source: Boolean? = null): CompletableFuture<Map<String, ArrayList<Any?>>>
 ```
 
 | Argument           | Type                                         | Description     |
 | ------------------ | -------------------------------------------- | --------------- |
 | `index`            | <pre>String</pre>                            | Index name      |
 | `collection`       | <pre>String</pre>                            | Collection name |
-| `searchQuery`      | <pre>ConcurrentHashMap<String, Any?></pre> | Query to match  |
-| `changes`          | <pre>ConcurrentHashMap<String, Any?></pre> | Partial changes to apply to the documents |
+| `searchQuery`      | <pre>Map<String, Any?></pre> | Query to match  |
+| `changes`          | <pre>Map<String, Any?></pre> | Partial changes to apply to the documents |
 | `waitForRefresh`   | <pre>Boolean</pre>                           | If set to `true`, Kuzzle will wait for the persistence layer to finish indexing|
 | `source`           | <pre>Boolean</pre>                           | If true, returns the updated document inside the response |
 
@@ -96,12 +96,12 @@ fun updateByQuery(
 
 ## Returns
 
-A `ConcurrentHashMap<String, ArrayList<Any?>>` which has a `successes` and `errors` `ArrayList<Any?>`:
+A `Map<String, ArrayList<Any?>>` which has a `successes` and `errors` `ArrayList<Any?>`:
 Each updated document is an object of the `successes` array with the following properties:
 
 | Property     | Type                                         | Description                      |
 |------------- |--------------------------------------------- |--------------------------------- |
-| `_source`    | <pre>ConcurrentHashMap<String, Any?></pre> | Updated document (if `source` option set to true)  |
+| `_source`    | <pre>Map<String, Any?></pre> | Updated document (if `source` option set to true)  |
 | `_id`        | <pre>String</pre>                            | ID of the udated document                   |
 | `_version`   | <pre>Int</pre>                           | Version of the document in the persistent data storage |
 | `status`     | <pre>Int</pre>                           | HTTP status code |
@@ -110,7 +110,7 @@ Each errored document is an object of the `errors` array with the following prop
 
 | Property     | Type                                         | Description                      |
 |------------- |--------------------------------------------- |--------------------------------- |
-| `document`   | <pre>ConcurrentHashMap<String, Any?></pre> | Document that causes the error   |
+| `document`   | <pre>Map<String, Any?></pre> | Document that causes the error   |
 | `status`     | <pre>Int</pre>                           | HTTP error status                |
 | `reason`     | <pre>String</pre>                            | Human readable reason |
 

--- a/doc/1/controllers/document/update-by-query/snippets/update-by-query-java.java
+++ b/doc/1/controllers/document/update-by-query/snippets/update-by-query-java.java
@@ -1,12 +1,12 @@
-    ConcurrentHashMap<String, Object> searchQuery = new ConcurrentHashMap<>();
-    ConcurrentHashMap<String, Object> match = new ConcurrentHashMap<>();
+    Map<String, Object> searchQuery = new HashMap<>();
+    Map<String, Object> match = new HashMap<>();
     match.put("capacity", 4);
     searchQuery.put("match", match);
 
-    ConcurrentHashMap<String, Object> changes = new ConcurrentHashMap<>();
+    Map<String, Object> changes = new HashMap<>();
     changes.put("capacity", 42);
 
-    ConcurrentHashMap<String, ArrayList<Object>> result = kuzzle
+    Map<String, ArrayList<Object>> result = kuzzle
         .getDocumentController()
         .updateByQuery("nyc-open-data", "yellow-taxi", searchQuery, changes)
         .get();

--- a/doc/1/controllers/document/update-by-query/snippets/update-by-query-kotlin.kt
+++ b/doc/1/controllers/document/update-by-query/snippets/update-by-query-kotlin.kt
@@ -1,20 +1,20 @@
-val match: ConcurrentHashMap<String, Any?> =
-  ConcurrentHashMap<String, Any?>().apply {
+val match: Map<String, Any?> =
+  Map<String, Any?>().apply {
     put("capacity", 4)
   }
 
-val searchQuery: ConcurrentHashMap<String, Any?> =
-  ConcurrentHashMap<String, Any?>().apply {
+val searchQuery: Map<String, Any?> =
+  Map<String, Any?>().apply {
     put("match", match)  
   }
 
-val changes: ConcurrentHashMap<String, Any?> =
-  ConcurrentHashMap<String, Any?>().apply {
+val changes: Map<String, Any?> =
+  Map<String, Any?>().apply {
     put("capacity", 42)
   }
 
 
-val result: ConcurrentHashMap<String, ArrayList<Any?>> =
+val result: Map<String, ArrayList<Any?>> =
   kuzzle
   .documentController
   .updateByQuery("nyc-open-data", "yellow-taxi", searchQuery, changes)

--- a/doc/1/controllers/document/update-by-query/snippets/update-by-query-kotlin.kt
+++ b/doc/1/controllers/document/update-by-query/snippets/update-by-query-kotlin.kt
@@ -1,15 +1,15 @@
 val match: Map<String, Any?> =
-  Map<String, Any?>().apply {
+  HashMap<String, Any?>().apply {
     put("capacity", 4)
   }
 
 val searchQuery: Map<String, Any?> =
-  Map<String, Any?>().apply {
+  HashMap<String, Any?>().apply {
     put("match", match)  
   }
 
 val changes: Map<String, Any?> =
-  Map<String, Any?>().apply {
+  HashMap<String, Any?>().apply {
     put("capacity", 42)
   }
 

--- a/doc/1/controllers/document/update/index.md
+++ b/doc/1/controllers/document/update/index.md
@@ -17,38 +17,38 @@ Updates a document.
 ## Arguments
  
 ```java
-public CompletableFuture<ConcurrentHashMap<String, Object>> update(
+public CompletableFuture<Map<String, Object>> update(
       String index,
       String collection,
       String id,
-      ConcurrentHashMap<String, Object> document,
+      Map<String, Object> document,
       Boolean waitForRefresh,
       Integer retryOnConflict,
       Boolean source)
 throws NotConnectedException, InternalException
 
-public CompletableFuture<ConcurrentHashMap<String, Object>> update(
+public CompletableFuture<Map<String, Object>> update(
       String index,
       String collection,
       String id,
-      ConcurrentHashMap<String, Object> document,
+      Map<String, Object> document,
       Boolean waitForRefresh,
       Integer retryOnConflict)
 throws NotConnectedException, InternalException
 
-public CompletableFuture<ConcurrentHashMap<String, Object>> update(
+public CompletableFuture<Map<String, Object>> update(
       String index,
       String collection,
       String id,
-      ConcurrentHashMap<String, Object> document,
+      Map<String, Object> document,
       Boolean waitForRefresh)
 throws NotConnectedException, InternalException
 
-public CompletableFuture<ConcurrentHashMap<String, Object>> update(
+public CompletableFuture<Map<String, Object>> update(
       String index,
       String collection,
       String id,
-      ConcurrentHashMap<String, Object> document)
+      Map<String, Object> document)
 throws NotConnectedException, InternalException
 ```
 
@@ -57,7 +57,7 @@ throws NotConnectedException, InternalException
 | `index`            | <pre>String</pre>                            | Index                             |
 | `collection`       | <pre>String</pre>                            | Collection                        |
 | `id        `       | <pre>String</pre>                            | Document ID                        |
-| `document`         | <pre>ConcurrentHashMap<String, Object></pre> | Partial document content |
+| `document`         | <pre>Map<String, Object></pre> | Partial document content |
 | `waitForRefresh`   | <pre>Boolean</pre>                           | If set to `true`, Kuzzle will wait for the persistence layer to finish indexing|
 | `retryOnConflict`  | <pre>Integer</pre>                           | The number of times the database layer should retry in case of version conflict |
 | `source`           | <pre>Boolean</pre>                           | If true, returns the updated document inside the response |
@@ -66,11 +66,11 @@ throws NotConnectedException, InternalException
 
 ## Return
 
-A `ConcurrentHashMap` which has the following properties:
+A `Map` which has the following properties:
 
 | Property     | Type                         | Description                                                    |
 |------------- |----------------------------- |--------------------------------------------------------------- |
-| `_source`    | <pre>ConcurrentHashMap</pre> | Updated document (If source option set to true)                |
+| `_source`    | <pre>Map</pre> | Updated document (If source option set to true)                |
 | `_id`        | <pre>String</pre>            | ID of the updated document                                     |
 | `_version`   | <pre>Integer</pre>           | Version of the document in the persistent data storage         |
 
@@ -88,10 +88,10 @@ A `ConcurrentHashMap` which has the following properties:
       index: String,
       collection: String,
       id: String?,
-      document: ConcurrentHashMap<String?, Any?>?,
+      document: Map<String?, Any?>?,
       waitForRefresh: Boolean? = null,
       retryOnConflict: Int? = null,
-      source: Boolean? = null): CompletableFuture<ConcurrentHashMap<String, Any?>>
+      source: Boolean? = null): CompletableFuture<Map<String, Any?>>
 ```
 
 | Arguments          | Type                                         | Description                       |
@@ -99,7 +99,7 @@ A `ConcurrentHashMap` which has the following properties:
 | `index`            | <pre>String</pre>                            | Index                             |
 | `collection`       | <pre>String</pre>                            | Collection                        |
 | `id        `       | <pre>String</pre>                            | Document ID                        |
-| `document`         | <pre>ConcurrentHashMap<String, Any?></pre> | Partial document content |
+| `document`         | <pre>Map<String, Any?></pre> | Partial document content |
 | `waitForRefresh`   | <pre>Boolean</pre>                           | If set to `true`, Kuzzle will wait for the persistence layer to finish indexing|
 | `retryOnConflict`  | <pre>Int</pre>                           | The number of times the database layer should retry in case of version conflict |
 | `source`           | <pre>Boolean</pre>                           | If true, returns the updated document inside the response |
@@ -108,11 +108,11 @@ A `ConcurrentHashMap` which has the following properties:
 
 ## Return
 
-A `ConcurrentHashMap` which has the following properties:
+A `Map` which has the following properties:
 
 | Property     | Type                         | Description                                                    |
 |------------- |----------------------------- |--------------------------------------------------------------- |
-| `_source`    | <pre>ConcurrentHashMap</pre> | Updated document (If source option set to true)                |
+| `_source`    | <pre>Map</pre> | Updated document (If source option set to true)                |
 | `_id`        | <pre>String</pre>            | ID of the updated document                                     |
 | `_version`   | <pre>Int</pre>           | Version of the document in the persistent data storage         |
 

--- a/doc/1/controllers/document/update/snippets/update-java.java
+++ b/doc/1/controllers/document/update/snippets/update-java.java
@@ -1,7 +1,7 @@
-    ConcurrentHashMap<String, Object> content = new ConcurrentHashMap<>();
+    Map<String, Object> content = new HashMap<>();
     content.put("name", "Johny");
 
-    ConcurrentHashMap<String, Object> result =
+    Map<String, Object> result =
     kuzzle.getDocumentController().update("nyc-open-data", "yellow-taxi", "some-id", content)
     .get();
 

--- a/doc/1/controllers/document/update/snippets/update-kotlin.kt
+++ b/doc/1/controllers/document/update/snippets/update-kotlin.kt
@@ -1,5 +1,5 @@
 val document: Map<String, Any?> =
-  Map<String, Any?>().apply {
+  HashMap<String, Any?>().apply {
     put("name", "Johny")
   }
 

--- a/doc/1/controllers/document/update/snippets/update-kotlin.kt
+++ b/doc/1/controllers/document/update/snippets/update-kotlin.kt
@@ -1,9 +1,9 @@
-val document: ConcurrentHashMap<String, Any?> =
-  ConcurrentHashMap<String, Any?>().apply {
+val document: Map<String, Any?> =
+  Map<String, Any?>().apply {
     put("name", "Johny")
   }
 
-val result: ConcurrentHashMap<String, Any?> =
+val result: Map<String, Any?> =
   kuzzle
   .documentController
   .update("nyc-open-data", "yellow-taxi", "some-id", document)

--- a/doc/1/controllers/document/validate/index.md
+++ b/doc/1/controllers/document/validate/index.md
@@ -22,7 +22,7 @@ This request does **not** store or publish the document.
 public CompletableFuture<Boolean> validate(
       String index,
       String collection,
-      ConcurrentHashMap<String, Object> document)
+      Map<String, Object> document)
 throws NotConnectedException, InternalException
 ```
 
@@ -30,7 +30,7 @@ throws NotConnectedException, InternalException
 | ------------ | -------------------------------------------- | -------------------- |
 | `index`      | <pre>String</pre>                            | Index name           |
 | `collection` | <pre>String</pre>                            | Collection name      |
-| `document`   | <pre>ConcurrentHashMap<String, Object></pre> | Document to validate |
+| `document`   | <pre>Map<String, Object></pre> | Document to validate |
 
 ## Returns
 
@@ -47,14 +47,14 @@ Returns a boolean value set to true if the document is valid and false otherwise
   fun validate(
       index: String,
       collection: String,
-      document: ConcurrentHashMap<String, Any?>): CompletableFuture<Boolean>
+      document: Map<String, Any?>): CompletableFuture<Boolean>
 ```
 
 | Argument     | Type                                         | Description          |
 | ------------ | -------------------------------------------- | -------------------- |
 | `index`      | <pre>String</pre>                            | Index name           |
 | `collection` | <pre>String</pre>                            | Collection name      |
-| `document`   | <pre>ConcurrentHashMap<String, Any?></pre> | Document to validate |
+| `document`   | <pre>Map<String, Any?></pre> | Document to validate |
 
 ## Returns
 

--- a/doc/1/controllers/document/validate/snippets/validate-java.java
+++ b/doc/1/controllers/document/validate/snippets/validate-java.java
@@ -1,4 +1,4 @@
-  ConcurrentHashMap<String, Object> document = new ConcurrentHashMap<>();
+  Map<String, Object> document = new HashMap<>();
   document.put("key", "value");
 
   Boolean result = kuzzle

--- a/doc/1/controllers/document/validate/snippets/validate-kotlin.kt
+++ b/doc/1/controllers/document/validate/snippets/validate-kotlin.kt
@@ -1,5 +1,5 @@
-val document: ConcurrentHashMap<String, Any?> =
-  ConcurrentHashMap<String, Any?>().apply {
+val document: Map<String, Any?> =
+  Map<String, Any?>().apply {
     put("key", "value")
   }
 

--- a/doc/1/controllers/document/validate/snippets/validate-kotlin.kt
+++ b/doc/1/controllers/document/validate/snippets/validate-kotlin.kt
@@ -1,5 +1,5 @@
 val document: Map<String, Any?> =
-  Map<String, Any?>().apply {
+  HashMap<String, Any?>().apply {
     put("key", "value")
   }
 

--- a/doc/1/controllers/realtime/count/snippets/count-java.java
+++ b/doc/1/controllers/realtime/count/snippets/count-java.java
@@ -1,4 +1,4 @@
-ConcurrentHashMap<String, Object> filters = new ConcurrentHashMap<>();
+Map<String, Object> filters = new HashMap<>();
 filters.put("exists", "name");
 
 final String roomId = kuzzle.getRealtimeController().subscribe(

--- a/doc/1/controllers/realtime/count/snippets/count-kotlin.kt
+++ b/doc/1/controllers/realtime/count/snippets/count-kotlin.kt
@@ -1,4 +1,4 @@
-val filters: ConcurrentHashMap<String, Any> = ConcurrentHashMap<String, Any>().apply {
+val filters: Map<String, Any> = Map<String, Any>().apply {
   put("exists", "name")
 }
 

--- a/doc/1/controllers/realtime/count/snippets/count-kotlin.kt
+++ b/doc/1/controllers/realtime/count/snippets/count-kotlin.kt
@@ -1,4 +1,4 @@
-val filters: Map<String, Any> = Map<String, Any>().apply {
+val filters: Map<String, Any> = HashMap<String, Any>().apply {
   put("exists", "name")
 }
 

--- a/doc/1/controllers/realtime/publish/index.md
+++ b/doc/1/controllers/realtime/publish/index.md
@@ -22,7 +22,7 @@ The index and collection are indicative and serve only to distinguish the rooms.
 public CompletableFuture<Integer> publish(
   String index, 
   String collection, 
-  ConcurrentHashMap<String, Object> message) 
+  Map<String, Object> message) 
     throws NotConnectedException, InternalException
 ```
 
@@ -30,7 +30,7 @@ public CompletableFuture<Integer> publish(
 |--------------|--------------------|-------------------------------------|
 | `index`      | <pre>String</pre>  | Index name                          |
 | `collection` | <pre>String</pre>  | Collection name                     |
-| `message`    | <pre>ConcurrentHashMap<String, Object></pre> | ConcurrentHashMap representing a JSON payload |
+| `message`    | <pre>Map<String, Object></pre> | Map representing a JSON payload |
 
 ## Usage
 
@@ -42,14 +42,14 @@ public CompletableFuture<Integer> publish(
 ## Arguments
 
 ```kotlin
-fun publish(index: String, collection: String, message: ConcurrentHashMap<String?, Any?>): CompletableFuture<Void>
+fun publish(index: String, collection: String, message: Map<String?, Any?>): CompletableFuture<Void>
 ```
 
 | Argument     | Type               | Description                         |
 |--------------|--------------------|-------------------------------------|
 | `index`      | <pre>String</pre>  | Index name                          |
 | `collection` | <pre>String</pre>  | Collection name                     |
-| `message`    | <pre>ConcurrentHashMap<String?, Any?></pre> | ConcurrentHashMap representing a JSON payload |
+| `message`    | <pre>Map<String?, Any?></pre> | Map representing a JSON payload |
 
 ## Usage
 

--- a/doc/1/controllers/realtime/publish/snippets/publish-java.java
+++ b/doc/1/controllers/realtime/publish/snippets/publish-java.java
@@ -1,4 +1,4 @@
-ConcurrentHashMap<String, Object> document = new ConcurrentHashMap<>();
+Map<String, Object> document = new HashMap<>();
 document.put("name", "nina-vkote");
 
 kuzzle.getRealtimeController().publish("my-index", "my-collection", document);

--- a/doc/1/controllers/realtime/publish/snippets/publish-kotlin.kt
+++ b/doc/1/controllers/realtime/publish/snippets/publish-kotlin.kt
@@ -1,4 +1,4 @@
-val document: Map<String?, Any?> = Map<String?, Any?>().apply {
+val document: Map<String?, Any?> = HashMap<String?, Any?>().apply {
   put("name", "nina-vkote")
 }
 

--- a/doc/1/controllers/realtime/publish/snippets/publish-kotlin.kt
+++ b/doc/1/controllers/realtime/publish/snippets/publish-kotlin.kt
@@ -1,4 +1,4 @@
-val document: ConcurrentHashMap<String?, Any?> = ConcurrentHashMap<String?, Any?>().apply {
+val document: Map<String?, Any?> = Map<String?, Any?>().apply {
   put("name", "nina-vkote")
 }
 

--- a/doc/1/controllers/realtime/subscribe/index.md
+++ b/doc/1/controllers/realtime/subscribe/index.md
@@ -18,18 +18,18 @@ Subscribes by providing a set of filters: messages, document changes and, option
 public CompletableFuture<String> subscribe(
   String index, 
   String collection, 
-  ConcurrentHashMap<String, Object> filters,
+  Map<String, Object> filters,
   String scope,
   String users,
   boolean subscribeToSelf,
-  ConcurrentHashMap<String, Object> volatiles,
+  Map<String, Object> volatiles,
   NotificationHandler handler, 
 ) throws NotConnectedException, InternalException
 
 public CompletableFuture<String> subscribe(
   String index, 
   String collection, 
-  ConcurrentHashMap<String, Object> filters,
+  Map<String, Object> filters,
   String scope,
   String users,
   boolean subscribeToSelf,
@@ -39,7 +39,7 @@ public CompletableFuture<String> subscribe(
 public CompletableFuture<String> subscribe(
   String index, 
   String collection, 
-  ConcurrentHashMap<String, Object> filters,
+  Map<String, Object> filters,
   String scope,
   String users,
   NotificationHandler handler, 
@@ -48,7 +48,7 @@ public CompletableFuture<String> subscribe(
 public CompletableFuture<String> subscribe(
   String index, 
   String collection, 
-  ConcurrentHashMap<String, Object> filters,
+  Map<String, Object> filters,
   String scope,
   NotificationHandler handler, 
 ) throws NotConnectedException, InternalException
@@ -56,7 +56,7 @@ public CompletableFuture<String> subscribe(
 public CompletableFuture<String> subscribe(
   String index, 
   String collection, 
-  ConcurrentHashMap<String, Object> filters,
+  Map<String, Object> filters,
   NotificationHandler handler, 
 ) throws NotConnectedException, InternalException
 ```
@@ -65,12 +65,12 @@ public CompletableFuture<String> subscribe(
 |--------------|-----------------------------------------|----------------------------------------------------------------------------------------------------------------|
 | `index`      | <pre>String</pre>                       | Index name                                                                                                     |
 | `collection` | <pre>String</pre>                       | Collection name                                                                                                |
-| `filters`    | <pre>ConcurrentHashMap<String, Object></pre>                      | ConcurrentHashMap representing a set of filters following [Koncorde syntax](/core/2/api/koncorde-filters-syntax) |
+| `filters`    | <pre>Map<String, Object></pre>                      | Map representing a set of filters following [Koncorde syntax](/core/2/api/koncorde-filters-syntax) |
 | `handler`   | <pre>NotificationHandler</pre>          | Handler function to handle notifications                                                                      |
 | `scope`    | <pre>String</pre><br>(`all`) | Subscribes to document entering or leaving the scope<br>Possible values: all, in, out, none |
 | `users`    | <pre>String</pre><br>(`none`) | Subscribes to users entering or leaving the room<br>Possible values: all, in, out, none |
 | `subscribeToSelf`    | <pre>boolean</pre><br>(`true`) | Subscribes to notifications fired by our own queries |
-| `volatile`    | <pre>ConcurrentHashMap<String, Object></pre><br>(`{}`) | ConcurrentHashMap representing subscription information, used in user join/leave notifications |
+| `volatile`    | <pre>Map<String, Object></pre><br>(`{}`) | Map representing subscription information, used in user join/leave notifications |
 
 ### handler
 
@@ -100,11 +100,11 @@ Subscription to document notifications with scope option_
 fun subscribe(
   index: String?,
   collection: String?,
-  filters: ConcurrentHashMap<String, Any>,
+  filters: Map<String, Any>,
   scope: String = "all",
   users: String = "all",
   subscribeToSelf: Boolean = true,
-  volatiles: ConcurrentHashMap<String?, Any?> = ConcurrentHashMap(),
+  volatiles: Map<String?, Any?> = Map(),
   handler: (Response) -> Unit): CompletableFuture<String>
 ```
 
@@ -112,12 +112,12 @@ fun subscribe(
 |--------------|-----------------------------------------|----------------------------------------------------------------------------------------------------------------|
 | `index`      | <pre>String</pre>                       | Index name                                                                                                     |
 | `collection` | <pre>String</pre>                       | Collection name                                                                                                |
-| `filters`    | <pre>ConcurrentHashMap<String, Object></pre>                      | ConcurrentHashMap representing a set of filters following [Koncorde syntax](/core/2/api/koncorde-filters-syntax) |
+| `filters`    | <pre>Map<String, Object></pre>                      | Map representing a set of filters following [Koncorde syntax](/core/2/api/koncorde-filters-syntax) |
 | `handler`   | <pre>NotificationHandler</pre>          | Handler function to handle notifications                                                                      |
 | `scope`    | <pre>String</pre><br>(`all`) | Subscribes to document entering or leaving the scope<br>Possible values: all, in, out, none |
 | `users`    | <pre>String</pre><br>(`none`) | Subscribes to users entering or leaving the room<br>Possible values: all, in, out, none |
 | `subscribeToSelf`    | <pre>boolean</pre><br>(`true`) | Subscribes to notifications fired by our own queries |
-| `volatile`    | <pre>ConcurrentHashMap<String, Object></pre><br>(`{}`) | ConcurrentHashMap representing subscription information, used in user join/leave notifications |
+| `volatile`    | <pre>Map<String, Object></pre><br>(`{}`) | Map representing subscription information, used in user join/leave notifications |
 
 ### handler
 

--- a/doc/1/controllers/realtime/subscribe/index.md
+++ b/doc/1/controllers/realtime/subscribe/index.md
@@ -104,7 +104,7 @@ fun subscribe(
   scope: String = "all",
   users: String = "all",
   subscribeToSelf: Boolean = true,
-  volatiles: Map<String?, Any?> = Map(),
+  volatiles: Map<String?, Any?> = HashMap(),
   handler: (Response) -> Unit): CompletableFuture<String>
 ```
 

--- a/doc/1/controllers/realtime/subscribe/snippets/document-notifications-java.java
+++ b/doc/1/controllers/realtime/subscribe/snippets/document-notifications-java.java
@@ -1,7 +1,7 @@
-ConcurrentHashMap<String, Object> filters = new ConcurrentHashMap<>();
+Map<String, Object> filters = new HashMap<>();
 filters.put("exists", "name");
 
-ConcurrentHashMap<String, Object> document = new ConcurrentHashMap<>();
+Map<String, Object> document = new HashMap<>();
 document.put("name", "nina-vkote");
 
 final String roomId = kuzzle.getRealtimeController().subscribe(
@@ -16,7 +16,7 @@ final String roomId = kuzzle.getRealtimeController().subscribe(
     }
 }).get();
 
-ConcurrentHashMap<String, Object> query = new ConcurrentHashMap<>();
+Map<String, Object> query = new HashMap<>();
 query.put("controller", "document");
 query.put("action", "create");
 query.put("index", "nyc-open-data");

--- a/doc/1/controllers/realtime/subscribe/snippets/document-notifications-kotlin.kt
+++ b/doc/1/controllers/realtime/subscribe/snippets/document-notifications-kotlin.kt
@@ -1,4 +1,4 @@
-val filters: Map<String, Any> = Map<String, Any>().apply {
+val filters: Map<String, Any> = HashMap<String, Any>().apply {
   put("exists", "name")
 }
 
@@ -13,10 +13,10 @@ val roomId: String = kuzzle.realtimeController.subscribe(
     }
   }.get()
 
-val document: Map<String, Any> = Map<String, Any>().apply {
+val document: Map<String, Any> = HashMap<String, Any>().apply {
   put("name", "nina-vkote")
 }
-val query: Map<String?, Any?> = Map<String?, Any?>().apply {
+val query: Map<String?, Any?> = HashMap<String?, Any?>().apply {
   put("controller", "document");
   put("action", "create");
   put("index", "nyc-open-data");

--- a/doc/1/controllers/realtime/subscribe/snippets/document-notifications-kotlin.kt
+++ b/doc/1/controllers/realtime/subscribe/snippets/document-notifications-kotlin.kt
@@ -1,4 +1,4 @@
-val filters: ConcurrentHashMap<String, Any> = ConcurrentHashMap<String, Any>().apply {
+val filters: Map<String, Any> = Map<String, Any>().apply {
   put("exists", "name")
 }
 
@@ -13,10 +13,10 @@ val roomId: String = kuzzle.realtimeController.subscribe(
     }
   }.get()
 
-val document: ConcurrentHashMap<String, Any> = ConcurrentHashMap<String, Any>().apply {
+val document: Map<String, Any> = Map<String, Any>().apply {
   put("name", "nina-vkote")
 }
-val query: ConcurrentHashMap<String?, Any?> = ConcurrentHashMap<String?, Any?>().apply {
+val query: Map<String?, Any?> = Map<String?, Any?>().apply {
   put("controller", "document");
   put("action", "create");
   put("index", "nyc-open-data");

--- a/doc/1/controllers/realtime/subscribe/snippets/document-notifications-leave-scope-java.java
+++ b/doc/1/controllers/realtime/subscribe/snippets/document-notifications-leave-scope-java.java
@@ -1,6 +1,6 @@
-ConcurrentHashMap<String, Object> filters = new ConcurrentHashMap<>();
-ConcurrentHashMap<String, Object> range = new ConcurrentHashMap<>();
-ConcurrentHashMap<String, Object> age = new ConcurrentHashMap<>();
+Map<String, Object> filters = new HashMap<>();
+Map<String, Object> range = new HashMap<>();
+Map<String, Object> age = new HashMap<>();
 
 age.put("lte", 20);
 range.put("age", age);
@@ -20,9 +20,9 @@ kuzzle.getRealtimeController().subscribe(
     }
   }).get();
 
-ConcurrentHashMap document = new ConcurrentHashMap<>();
+Map document = new HashMap<>();
 document.put("age", 19);
-ConcurrentHashMap<String, Object> query = new ConcurrentHashMap<>();
+Map<String, Object> query = new HashMap<>();
 query.put("controller", "document");
 query.put("action", "create");
 query.put("index", "nyc-open-data");

--- a/doc/1/controllers/realtime/subscribe/snippets/document-notifications-leave-scope-kotlin.kt
+++ b/doc/1/controllers/realtime/subscribe/snippets/document-notifications-leave-scope-kotlin.kt
@@ -1,6 +1,6 @@
 val filters: Map<String, Any> = HashMap<String, Any>().apply {
-  put("range", Map<String, Any>().apply {
-    put("age", Map<String, Any>().apply {
+  put("range",= HashMap<{
+    put("age",= HashMap<{
       put("lte", 20)
     })
   })

--- a/doc/1/controllers/realtime/subscribe/snippets/document-notifications-leave-scope-kotlin.kt
+++ b/doc/1/controllers/realtime/subscribe/snippets/document-notifications-leave-scope-kotlin.kt
@@ -1,6 +1,6 @@
-val filters: ConcurrentHashMap<String, Any> = ConcurrentHashMap<String, Any>().apply {
-  put("range", ConcurrentHashMap<String, Any>().apply {
-    put("age", ConcurrentHashMap<String, Any>().apply {
+val filters: Map<String, Any> = Map<String, Any>().apply {
+  put("range", Map<String, Any>().apply {
+    put("age", Map<String, Any>().apply {
       put("lte", 20)
     })
   })
@@ -17,10 +17,10 @@ val roomId: String = kuzzle.realtimeController.subscribe(
   }
 }.get()
 
-val document: ConcurrentHashMap<String, Any> = ConcurrentHashMap<String, Any>().apply {
+val document: Map<String, Any> = Map<String, Any>().apply {
   put("age", 19)
 }
-val query: ConcurrentHashMap<String?, Any?> = ConcurrentHashMap<String?, Any?>().apply {
+val query: Map<String?, Any?> = Map<String?, Any?>().apply {
   put("controller", "document");
   put("action", "create");
   put("index", "nyc-open-data");

--- a/doc/1/controllers/realtime/subscribe/snippets/document-notifications-leave-scope-kotlin.kt
+++ b/doc/1/controllers/realtime/subscribe/snippets/document-notifications-leave-scope-kotlin.kt
@@ -1,6 +1,6 @@
 val filters: Map<String, Any> = HashMap<String, Any>().apply {
-  put("range",= HashMap<{
-    put("age",= HashMap<{
+  put("range", HashMap<String, Any>().apply{
+    put("age", HashMap<String, Any>().apply{
       put("lte", 20)
     })
   })

--- a/doc/1/controllers/realtime/subscribe/snippets/document-notifications-leave-scope-kotlin.kt
+++ b/doc/1/controllers/realtime/subscribe/snippets/document-notifications-leave-scope-kotlin.kt
@@ -1,6 +1,6 @@
 val filters: Map<String, Any> = HashMap<String, Any>().apply {
-  put("range", HashMap<String, Any>().apply{
-    put("age", HashMap<String, Any>().apply{
+  put("range", HashMap<String, Any>().apply {
+    put("age", HashMap<String, Any>().apply {
       put("lte", 20)
     })
   })
@@ -17,10 +17,10 @@ val roomId: String = kuzzle.realtimeController.subscribe(
   }
 }.get()
 
-val document: Map<String, Any> = HashMap<String, Any>().apply {
+val document = HashMap<String, Any>().apply {
   put("age", 19)
 }
-val query: Map<String?, Any?> = HashMap<String?, Any?>().apply {
+val query = HashMap<String?, Any?>().apply {
   put("controller", "document");
   put("action", "create");
   put("index", "nyc-open-data");

--- a/doc/1/controllers/realtime/subscribe/snippets/document-notifications-leave-scope-kotlin.kt
+++ b/doc/1/controllers/realtime/subscribe/snippets/document-notifications-leave-scope-kotlin.kt
@@ -1,4 +1,4 @@
-val filters: Map<String, Any> = Map<String, Any>().apply {
+val filters: Map<String, Any> = HashMap<String, Any>().apply {
   put("range", Map<String, Any>().apply {
     put("age", Map<String, Any>().apply {
       put("lte", 20)
@@ -17,10 +17,10 @@ val roomId: String = kuzzle.realtimeController.subscribe(
   }
 }.get()
 
-val document: Map<String, Any> = Map<String, Any>().apply {
+val document: Map<String, Any> = HashMap<String, Any>().apply {
   put("age", 19)
 }
-val query: Map<String?, Any?> = Map<String?, Any?>().apply {
+val query: Map<String?, Any?> = HashMap<String?, Any?>().apply {
   put("controller", "document");
   put("action", "create");
   put("index", "nyc-open-data");

--- a/doc/1/controllers/realtime/unsubscribe/snippets/unsubscribe-java.java
+++ b/doc/1/controllers/realtime/unsubscribe/snippets/unsubscribe-java.java
@@ -1,7 +1,7 @@
-ConcurrentHashMap<String, Object> filters = new ConcurrentHashMap<>();
+Map<String, Object> filters = new HashMap<>();
 filters.put("exists", "name");
 
-ConcurrentHashMap<String, Object> document = new ConcurrentHashMap<>();
+Map<String, Object> document = new HashMap<>();
 document.put("name", "nina-vkote");
 
 final String roomId = kuzzle.getRealtimeController().subscribe(

--- a/doc/1/controllers/realtime/unsubscribe/snippets/unsubscribe-kotlin.kt
+++ b/doc/1/controllers/realtime/unsubscribe/snippets/unsubscribe-kotlin.kt
@@ -1,4 +1,4 @@
-val filters: ConcurrentHashMap<String, Any> = ConcurrentHashMap<String, Any>().apply {
+val filters: Map<String, Any> = Map<String, Any>().apply {
   put("exists", "name")
 }
 
@@ -13,7 +13,7 @@ val roomId: String = kuzzle.realtimeController.subscribe(
   }
 }.get()
 
-val document: ConcurrentHashMap<String, Any> = ConcurrentHashMap<String, Any>().apply {
+val document: Map<String, Any> = Map<String, Any>().apply {
   put("name", "nina-vkote")
 }
 

--- a/doc/1/controllers/realtime/unsubscribe/snippets/unsubscribe-kotlin.kt
+++ b/doc/1/controllers/realtime/unsubscribe/snippets/unsubscribe-kotlin.kt
@@ -1,4 +1,4 @@
-val filters: Map<String, Any> = Map<String, Any>().apply {
+val filters: Map<String, Any> = HashMap<String, Any>().apply {
   put("exists", "name")
 }
 
@@ -13,7 +13,7 @@ val roomId: String = kuzzle.realtimeController.subscribe(
   }
 }.get()
 
-val document: Map<String, Any> = Map<String, Any>().apply {
+val document: Map<String, Any> = HashMap<String, Any>().apply {
   put("name", "nina-vkote")
 }
 

--- a/doc/1/controllers/server/get-all-stats/index.md
+++ b/doc/1/controllers/server/get-all-stats/index.md
@@ -21,12 +21,12 @@ These statistics include:
 ::: tab Java
 
 ```java
-CompletableFuture<ConcurrentHashMap<String, Object>> getAllStats()
+CompletableFuture<Map<String, Object>> getAllStats()
 ```
 
 ## Return
 
-Returns a `ConcurrentHashMap<String, Object>` containing all stored internal statistic snapshots.
+Returns a `Map<String, Object>` containing all stored internal statistic snapshots.
 
 ## Usage
 
@@ -35,12 +35,12 @@ Returns a `ConcurrentHashMap<String, Object>` containing all stored internal sta
 ::: tab Kotlin
 
 ```kotlin
-fun getAllStats(): CompletableFuture<ConcurrentHashMap<String, Any?>>
+fun getAllStats(): CompletableFuture<Map<String, Any?>>
 ```
 
 ## Return
 
-Returns a `ConcurrentHashMap<String, Any?>` containing all stored internal statistic snapshots.
+Returns a `Map<String, Any?>` containing all stored internal statistic snapshots.
 
 ## Usage
 

--- a/doc/1/controllers/server/get-all-stats/snippets/get-all-stats-java.java
+++ b/doc/1/controllers/server/get-all-stats/snippets/get-all-stats-java.java
@@ -1,4 +1,4 @@
-ConcurrentHashMap<String, Object> result = kuzzle
+Map<String, Object> result = kuzzle
     .getServerController()
     .getAllStats()
     .get();

--- a/doc/1/controllers/server/get-all-stats/snippets/get-all-stats-kotlin.kt
+++ b/doc/1/controllers/server/get-all-stats/snippets/get-all-stats-kotlin.kt
@@ -1,4 +1,4 @@
-val result: ConcurrentHashMap<String, Any?> = kuzzle
+val result: Map<String, Any?> = kuzzle
     .serverController
     .getAllStats()
     .get()

--- a/doc/1/controllers/server/get-config/index.md
+++ b/doc/1/controllers/server/get-config/index.md
@@ -17,12 +17,12 @@ This route should only be accessible to administrators, as it might return sensi
 ::: tab Java
 
 ```java
-CompletableFuture<ConcurrentHashMap<String, Object>> getConfig()
+CompletableFuture<Map<String, Object>> getConfig()
 ```
 
 ## Return
 
-Returns a `ConcurrentHashMap<String, Object>` containing server configuration.
+Returns a `Map<String, Object>` containing server configuration.
 
 ## Usage
 
@@ -31,12 +31,12 @@ Returns a `ConcurrentHashMap<String, Object>` containing server configuration.
 ::: tab Kotlin
 
 ```kotlin
-fun getConfig(): CompletableFuture<ConcurrentHashMap<String, Any?>>
+fun getConfig(): CompletableFuture<Map<String, Any?>>
 ```
 
 ## Return
 
-Returns a `ConcurrentHashMap<String, Any?>` containing server configuration.
+Returns a `Map<String, Any?>` containing server configuration.
 
 ## Usage
 

--- a/doc/1/controllers/server/get-config/snippets/get-config-java.java
+++ b/doc/1/controllers/server/get-config/snippets/get-config-java.java
@@ -1,4 +1,4 @@
-ConcurrentHashMap<String, Object> result = kuzzle
+Map<String, Object> result = kuzzle
     .getServerController()
     .getConfig()
     .get();

--- a/doc/1/controllers/server/get-config/snippets/get-config-kotlin.kt
+++ b/doc/1/controllers/server/get-config/snippets/get-config-kotlin.kt
@@ -1,4 +1,4 @@
-val result: ConcurrentHashMap<String, Any?> = kuzzle
+val result: Map<String, Any?> = kuzzle
     .serverController
     .getConfig()
     .get()

--- a/doc/1/controllers/server/get-last-stats/index.md
+++ b/doc/1/controllers/server/get-last-stats/index.md
@@ -22,12 +22,12 @@ These statistics include:
 ::: tab Java
 
 ```java
-CompletableFuture<ConcurrentHashMap<String, Object>> getLastStats()
+CompletableFuture<Map<String, Object>> getLastStats()
 ```
 
 ## Return
 
-Returns an `ConcurrentHashMap<String, Object>` containing the most recent statistics snapshot.
+Returns an `Map<String, Object>` containing the most recent statistics snapshot.
 
 ## Usage
 
@@ -36,12 +36,12 @@ Returns an `ConcurrentHashMap<String, Object>` containing the most recent statis
 ::: tab Kotlin
 
 ```kotlin
-fun getConfig(): CompletableFuture<ConcurrentHashMap<String, Any?>>
+fun getConfig(): CompletableFuture<Map<String, Any?>>
 ```
 
 ## Return
 
-Returns an `ConcurrentHashMap<String, Any?>` containing the most recent statistics snapshot.
+Returns an `Map<String, Any?>` containing the most recent statistics snapshot.
 
 ## Usage
 

--- a/doc/1/controllers/server/get-last-stats/snippets/get-last-stats-java.java
+++ b/doc/1/controllers/server/get-last-stats/snippets/get-last-stats-java.java
@@ -1,4 +1,4 @@
-ConcurrentHashMap<String, Object> result = kuzzle
+Map<String, Object> result = kuzzle
     .getServerController()
     .getLastStats()
     .get();

--- a/doc/1/controllers/server/get-last-stats/snippets/get-last-stats-kotlin.kt
+++ b/doc/1/controllers/server/get-last-stats/snippets/get-last-stats-kotlin.kt
@@ -1,4 +1,4 @@
-val result: ConcurrentHashMap<String, Any?> = kuzzle
+val result: Map<String, Any?> = kuzzle
     .serverController
     .getLastStats()
     .get()

--- a/doc/1/controllers/server/get-stats/index.md
+++ b/doc/1/controllers/server/get-stats/index.md
@@ -21,7 +21,7 @@ These statistics include:
 ::: tab Java
 
 ```java
-CompletableFuture<ConcurrentHashMap<String, Object>> getStats(
+CompletableFuture<Map<String, Object>> getStats(
       Date startTime, Date stopTime)
 ```
 
@@ -34,7 +34,7 @@ CompletableFuture<ConcurrentHashMap<String, Object>> getStats(
 
 ## Return
 
-Returns a `ConcurrentHashMap<String, Object>` containing statistics snapshots within the provided range.
+Returns a `Map<String, Object>` containing statistics snapshots within the provided range.
 
 ## Usage
 
@@ -43,7 +43,7 @@ Returns a `ConcurrentHashMap<String, Object>` containing statistics snapshots wi
 ::: tab Kotlin
 
 ```kotlin
-fun getStats(startTime: Date, stopTime: Date): CompletableFuture<ConcurrentHashMap<String, Any?>>
+fun getStats(startTime: Date, stopTime: Date): CompletableFuture<Map<String, Any?>>
 ```
 
 <br/>
@@ -55,7 +55,7 @@ fun getStats(startTime: Date, stopTime: Date): CompletableFuture<ConcurrentHashM
 
 ## Return
 
-Returns a `ConcurrentHashMap<String, Any?>` containing statistics snapshots within the provided range.
+Returns a `Map<String, Any?>` containing statistics snapshots within the provided range.
 
 ## Usage
 

--- a/doc/1/controllers/server/get-stats/snippets/get-stats-java.java
+++ b/doc/1/controllers/server/get-stats/snippets/get-stats-java.java
@@ -1,7 +1,7 @@
 Date startTime = new Date(1234567890);
 Date stopTime = new Date(1541426610);
 
-ConcurrentHashMap<String, Object> result = kuzzle
+Map<String, Object> result = kuzzle
     .getServerController()
     .getStats(startTime, stopTime)
     .get();

--- a/doc/1/controllers/server/get-stats/snippets/get-stats-kotlin.kt
+++ b/doc/1/controllers/server/get-stats/snippets/get-stats-kotlin.kt
@@ -1,7 +1,7 @@
 val startTime = Date(1234567890000);
 val stopTime = Date(1541426610000);
 
-val result: ConcurrentHashMap<String, Any?> = kuzzle
+val result: Map<String, Any?> = kuzzle
     .serverController
     .getStats(startTime, stopTime)
     .get()

--- a/doc/1/controllers/server/info/index.md
+++ b/doc/1/controllers/server/info/index.md
@@ -13,7 +13,7 @@ Returns information about Kuzzle: available API (base + extended), plugins, exte
 ::: tab Java
 
 ```java
-CompletableFuture<ConcurrentHashMap<String, Object>> info()
+CompletableFuture<Map<String, Object>> info()
 ```
 
 ## Return
@@ -27,12 +27,12 @@ Returns a `Map<String, dynamic>` containing server information.
 ::: tab Kotlin
 
 ```kotlin
-fun info(): CompletableFuture<ConcurrentHashMap<String, Any?>>
+fun info(): CompletableFuture<Map<String, Any?>>
 ```
 
 ## Return
 
-Returns a `ConcurrentHashMap<String, Object>` containing server information.
+Returns a `Map<String, Object>` containing server information.
 
 ## Usage
 

--- a/doc/1/controllers/server/info/snippets/info-java.java
+++ b/doc/1/controllers/server/info/snippets/info-java.java
@@ -1,4 +1,4 @@
-ConcurrentHashMap<String, Object> result = kuzzle
+Map<String, Object> result = kuzzle
   .getServerController()
   .info()
   .get();

--- a/doc/1/controllers/server/info/snippets/info-kotlin.kt
+++ b/doc/1/controllers/server/info/snippets/info-kotlin.kt
@@ -1,4 +1,4 @@
-val result: ConcurrentHashMap<String, Any?> = kuzzle
+val result: Map<String, Any?> = kuzzle
     .serverController
     .info()
     .get()

--- a/doc/1/core-classes/kuzzle/query/index.md
+++ b/doc/1/core-classes/kuzzle/query/index.md
@@ -20,7 +20,7 @@ This is a low-level method, exposed to allow advanced SDK users to bypass high-l
 
 ```java
 public CompletableFuture<Response> query(
-  ConcurrentHashMap<String, Object> query)
+  Map<String, Object> query)
       throws InternalException, NotConnectedException
 ```
 
@@ -28,7 +28,7 @@ public CompletableFuture<Response> query(
 
 | Argument  | Type              | Description            |
 | --------- | ----------------- | ---------------------- |
-| `query` | <pre>ConcurrentHashMap<String, Object></pre> | API request    |
+| `query` | <pre>Map<String, Object></pre> | API request    |
 
 ### query
 
@@ -39,11 +39,11 @@ The following properties are the most common.
 | ------------ | ----------------- | ---------------------------------------- |
 | `controller` | <pre>String</pre> | Controller name (mandatory)              |
 | `action`     | <pre>String</pre> | Action name (mandatory)                  |
-| `body`       | <pre>ConcurrentHashMap<String, Object></pre> | Query body for this action               |
+| `body`       | <pre>Map<String, Object></pre> | Query body for this action               |
 | `index`      | <pre>String</pre> | Index name for this action               |
 | `collection` | <pre>String</pre> | Collection name for this action          |
 | `_id`        | <pre>String</pre> | id for this action                       |
-| `volatile`   | <pre>ConcurrentHashMap<String, Object></pre> | Additional information to send to Kuzzle |
+| `volatile`   | <pre>Map<String, Object></pre> | Additional information to send to Kuzzle |
 
 ## Returns
 
@@ -59,14 +59,14 @@ Returns a [Response](/sdk/jvm/1/core-classes/response) object which represents a
 ## Arguments
 
 ```kotlin
-fun query(query: ConcurrentHashMap<String?, Any?>): CompletableFuture<Response>
+fun query(query: Map<String?, Any?>): CompletableFuture<Response>
 ```
 
 <br/>
 
 | Argument  | Type              | Description            |
 | --------- | ----------------- | ---------------------- |
-| `query` | <pre>ConcurrentHashMap<String?, Any?></pre> | API request    |
+| `query` | <pre>Map<String?, Any?></pre> | API request    |
 
 ### query
 
@@ -77,11 +77,11 @@ The following properties are the most common.
 | ------------ | ----------------- | ---------------------------------------- |
 | `controller` | <pre>String</pre> | Controller name (mandatory)              |
 | `action`     | <pre>String</pre> | Action name (mandatory)                  |
-| `body`       | <pre>ConcurrentHashMap<String, Object></pre> | Query body for this action               |
+| `body`       | <pre>Map<String, Object></pre> | Query body for this action               |
 | `index`      | <pre>String</pre> | Index name for this action               |
 | `collection` | <pre>String</pre> | Collection name for this action          |
 | `_id`        | <pre>String</pre> | id for this action                       |
-| `volatile`   | <pre>ConcurrentHashMap<String, Object></pre> | Additional information to send to Kuzzle |
+| `volatile`   | <pre>Map<String, Object></pre> | Additional information to send to Kuzzle |
 
 ## Returns
 

--- a/doc/1/core-classes/kuzzle/query/snippets/query-java.java
+++ b/doc/1/core-classes/kuzzle/query/snippets/query-java.java
@@ -1,11 +1,11 @@
-ConcurrentHashMap<String, Object> query = new ConcurrentHashMap<>();
+Map<String, Object> query = new HashMap<>();
 query.put("controller", "document");
 query.put("action", "create");
 query.put("index", "nyc-open-data");
 query.put("collection", "yellow-taxi");
 query.put("_id", "my-custom-document-id");
 query.put("refresh", "wait_for");
-ConcurrentHashMap<String, Object> body = new ConcurrentHashMap<>();
+Map<String, Object> body = new HashMap<>();
 body.put("trip_distance", 4.23);
 body.put("passenger_count", 2);
 query.put("body", body);

--- a/doc/1/core-classes/kuzzle/query/snippets/query-kotlin.kt
+++ b/doc/1/core-classes/kuzzle/query/snippets/query-kotlin.kt
@@ -1,11 +1,11 @@
-val query: ConcurrentHashMap<String?, Any?> = ConcurrentHashMap<String?, Any?>().apply {
+val query: Map<String?, Any?> = Map<String?, Any?>().apply {
   put("controller", "document")
   put("action", "create")
   put("index", "nyc-open-data")
   put("collection", "yellow-taxi")
   put("_id", "my-custom-document-id")
   put("refresh", "wait_for")
-  put("body", ConcurrentHashMap<String?, Any?>().apply {
+  put("body", Map<String?, Any?>().apply {
     put("trip_distance", 4.23)
     put("passenger_count", 2)
   })

--- a/doc/1/core-classes/kuzzle/query/snippets/query-kotlin.kt
+++ b/doc/1/core-classes/kuzzle/query/snippets/query-kotlin.kt
@@ -1,4 +1,4 @@
-val query: Map<String?, Any?> = Map<String?, Any?>().apply {
+val query: Map<String?, Any?> = HashMap<String?, Any?>().apply {
   put("controller", "document")
   put("action", "create")
   put("index", "nyc-open-data")

--- a/doc/1/core-classes/kuzzle/query/snippets/query-kotlin.kt
+++ b/doc/1/core-classes/kuzzle/query/snippets/query-kotlin.kt
@@ -5,7 +5,7 @@ val query: Map<String?, Any?> = HashMap<String?, Any?>().apply {
   put("collection", "yellow-taxi")
   put("_id", "my-custom-document-id")
   put("refresh", "wait_for")
-  put("body", Map<String?, Any?>().apply {
+  put("body", HashMap<String?, Any?>().apply {
     put("trip_distance", 4.23)
     put("passenger_count", 2)
   })

--- a/doc/1/core-classes/response/introduction/index.md
+++ b/doc/1/core-classes/response/introduction/index.md
@@ -27,4 +27,4 @@ order: 0
 | `state` | <pre>String</pre> | Document state (realtime only) |
 | `status` | <pre>int</pre> | Response status, following HTTP status codes |
 | `timestamp` | <pre>Long</pre> | Notification timestamp (UTC) |
-| `volatile` | <pre>ConcurrentHashMap<String, Object></pre> | Volatile data |
+| `volatile` | <pre>Map<String, Object></pre> | Volatile data |

--- a/doc/1/core-classes/search-result/introduction/index.md
+++ b/doc/1/core-classes/search-result/introduction/index.md
@@ -29,20 +29,20 @@ import io.kuzzle.sdk.coreClasses.SearchResult;
 
 | Property       | Type                                                    | Description        |
 | -------------- | ------------------------------------------------------- | ------------------ |
-| `aggregations` | <pre>ConcurrentHashMap<String, Object></pre>            | Search aggregations (can be undefined) |
-| `hits`         | <pre>ArrayList<ConcurrentHashMap<String, Object>></pre> | Page results       |
+| `aggregations` | <pre>Map<String, Object></pre>            | Search aggregations (can be undefined) |
+| `hits`         | <pre>ArrayList<Map<String, Object>></pre> | Page results       |
 | `total`        | <pre>Integer</pre>                                      |  Total number of items that _can_ be retrieved |
 | `fetched`      | <pre>Integer</pre>                                      | Number of retrieved items so far   |
 
 ### hits
 
-Each element of the `hits` ArrayList is a `ConcurrentHashMap<String, Object>` containing the following properties:
+Each element of the `hits` ArrayList is a `Map<String, Object>` containing the following properties:
 
 | Property  | Type               | Description            |
 | --------- | ------------------ | ---------------------- |
 | `_id`     | <pre>String</pre>  | Document ID            |
 | `_score`  | <pre>Integer</pre> | [Relevance score](https://www.elastic.co/guide/en/elasticsearch/guide/current/relevance-intro.html) |
-| `_source` | <pre>ConcurrentHashMap<String, Object></pre> | Document content |
+| `_source` | <pre>Map<String, Object></pre> | Document content |
 
 
 :::
@@ -59,20 +59,20 @@ import io.kuzzle.sdk.coreClasses.SearchResult;
 
 | Property       | Type                                                    | Description        |
 | -------------- | ------------------------------------------------------- | ------------------ |
-| `aggregations` | <pre>ConcurrentHashMap<String, Any></pre>            | Search aggregations (can be undefined) |
-| `hits`         | <pre>ArrayList<ConcurrentHashMap<String, Any>></pre> | Page results       |
+| `aggregations` | <pre>Map<String, Any></pre>            | Search aggregations (can be undefined) |
+| `hits`         | <pre>ArrayList<Map<String, Any>></pre> | Page results       |
 | `total`        | <pre>Int</pre>                                      |  Total number of items that _can_ be retrieved |
 | `fetched`      | <pre>Int</pre>                                      | Number of retrieved items so far   |
 
 ### hits
 
-Each element of the `hits` ArrayList is a `ConcurrentHashMap<String, Object>` containing the following properties:
+Each element of the `hits` ArrayList is a `Map<String, Object>` containing the following properties:
 
 | Property  | Type               | Description            |
 | --------- | ------------------ | ---------------------- |
 | `_id`     | <pre>String</pre>  | Document ID            |
 | `_score`  | <pre>Int</pre> | [Relevance score](https://www.elastic.co/guide/en/elasticsearch/guide/current/relevance-intro.html) |
-| `_source` | <pre>ConcurrentHashMap<String, Any?></pre> | Document content |
+| `_source` | <pre>Map<String, Any?></pre> | Document content |
 
 :::
 ::::

--- a/doc/1/core-classes/search-result/next/snippets/fromsize-java.java
+++ b/doc/1/core-classes/search-result/next/snippets/fromsize-java.java
@@ -1,6 +1,6 @@
-    ConcurrentHashMap<String, Object> searchQuery = new ConcurrentHashMap<>();
-    ConcurrentHashMap<String, Object> query = new ConcurrentHashMap<>();
-    ConcurrentHashMap<String, Object> match = new ConcurrentHashMap<>();
+    Map<String, Object> searchQuery = new HashMap<>();
+    Map<String, Object> query = new HashMap<>();
+    Map<String, Object> match = new HashMap<>();
     match.put("category", "suv");
     query.put("match", match);
     searchQuery.put("query", query);
@@ -11,7 +11,7 @@
       searchQuery, 1, 5).get();
 
     // Fetch the matched items by advancing through the result pages
-    ArrayList<ConcurrentHashMap<String, Object>> matched = new ArrayList<>();
+    ArrayList<Map<String, Object>> matched = new ArrayList<>();
 
     while (results != null) {
       matched.addAll(results.hits);

--- a/doc/1/core-classes/search-result/next/snippets/fromsize-kotlin.kt
+++ b/doc/1/core-classes/search-result/next/snippets/fromsize-kotlin.kt
@@ -1,15 +1,15 @@
-val match: ConcurrentHashMap<String, Any?> =
-ConcurrentHashMap<String, Any?>().apply {
+val match: Map<String, Any?> =
+Map<String, Any?>().apply {
   put("category", "suv")
 }
 
-val query: ConcurrentHashMap<String, Any?> =
-ConcurrentHashMap<String, Any?>().apply {
+val query: Map<String, Any?> =
+Map<String, Any?>().apply {
   put("match", match)
 }
 
-val searchQuery: ConcurrentHashMap<String, Any?> =
-ConcurrentHashMap<String, Any?>().apply {
+val searchQuery: Map<String, Any?> =
+Map<String, Any?>().apply {
   put("query", query)
 }
 
@@ -18,7 +18,7 @@ var result: SearchResult? = kuzzle
   .search("nyc-open-data", "yellow-taxi", searchQuery, 5, 1).get();
 
 // Fetch the matched items by advancing through the result pages
-val matched: ArrayList<ConcurrentHashMap<String, Any>> = ArrayList<ConcurrentHashMap<String, Any>>();
+val matched: ArrayList<Map<String, Any>> = ArrayList<Map<String, Any>>();
 while (result != null) {
   matched.addAll(result.hits);
   result = result.next().get();

--- a/doc/1/core-classes/search-result/next/snippets/fromsize-kotlin.kt
+++ b/doc/1/core-classes/search-result/next/snippets/fromsize-kotlin.kt
@@ -1,15 +1,15 @@
 val match: Map<String, Any?> =
-Map<String, Any?>().apply {
+HashMap<String, Any?>().apply {
   put("category", "suv")
 }
 
 val query: Map<String, Any?> =
-Map<String, Any?>().apply {
+HashMap<String, Any?>().apply {
   put("match", match)
 }
 
 val searchQuery: Map<String, Any?> =
-Map<String, Any?>().apply {
+HashMap<String, Any?>().apply {
   put("query", query)
 }
 

--- a/doc/1/core-classes/search-result/next/snippets/scroll-java.java
+++ b/doc/1/core-classes/search-result/next/snippets/scroll-java.java
@@ -1,6 +1,6 @@
-    ConcurrentHashMap<String, Object> searchQuery = new ConcurrentHashMap<>();
-    ConcurrentHashMap<String, Object> query = new ConcurrentHashMap<>();
-    ConcurrentHashMap<String, Object> match = new ConcurrentHashMap<>();
+    Map<String, Object> searchQuery = new HashMap<>();
+    Map<String, Object> query = new HashMap<>();
+    Map<String, Object> match = new HashMap<>();
     match.put("category", "suv");
     query.put("match", match);
     searchQuery.put("query", query);
@@ -11,7 +11,7 @@
       searchQuery, "1s", 10).get();
 
     // Fetch the matched items by advancing through the result pages
-    ArrayList<ConcurrentHashMap<String, Object>> matched = new ArrayList<>();
+    ArrayList<Map<String, Object>> matched = new ArrayList<>();
 
     while (results != null) {
       matched.addAll(results.hits);

--- a/doc/1/core-classes/search-result/next/snippets/scroll-kotlin.kt
+++ b/doc/1/core-classes/search-result/next/snippets/scroll-kotlin.kt
@@ -1,14 +1,14 @@
 val match: Map<String, Any?> =
-Map<String, Any?>().apply {
+HashMap<String, Any?>().apply {
   put("category", "suv")
 }
 val query: Map<String, Any?> =
-Map<String, Any?>().apply {
+HashMap<String, Any?>().apply {
   put("match", match)
 }
 
 val searchQuery: Map<String, Any?> =
-Map<String, Any?>().apply {
+HashMap<String, Any?>().apply {
   put("query", query)
 }
 var result: SearchResult? = kuzzle

--- a/doc/1/core-classes/search-result/next/snippets/scroll-kotlin.kt
+++ b/doc/1/core-classes/search-result/next/snippets/scroll-kotlin.kt
@@ -1,14 +1,14 @@
-val match: ConcurrentHashMap<String, Any?> =
-ConcurrentHashMap<String, Any?>().apply {
+val match: Map<String, Any?> =
+Map<String, Any?>().apply {
   put("category", "suv")
 }
-val query: ConcurrentHashMap<String, Any?> =
-ConcurrentHashMap<String, Any?>().apply {
+val query: Map<String, Any?> =
+Map<String, Any?>().apply {
   put("match", match)
 }
 
-val searchQuery: ConcurrentHashMap<String, Any?> =
-ConcurrentHashMap<String, Any?>().apply {
+val searchQuery: Map<String, Any?> =
+Map<String, Any?>().apply {
   put("query", query)
 }
 var result: SearchResult? = kuzzle
@@ -16,7 +16,7 @@ var result: SearchResult? = kuzzle
   .search("nyc-open-data", "yellow-taxi", searchQuery, "1s", 10).get();
 
     // Fetch the matched items by advancing through the result pages
-    val matched: ArrayList<ConcurrentHashMap<String, Any>> = ArrayList<ConcurrentHashMap<String, Any>>();
+    val matched: ArrayList<Map<String, Any>> = ArrayList<Map<String, Any>>();
 
     while (result != null) {
       matched.addAll(result.hits);

--- a/doc/1/getting-started/java/index.md
+++ b/doc/1/getting-started/java/index.md
@@ -152,7 +152,7 @@ New created document notification:
 
 ```
 
-You should see the document content as a `ConcurrentHashMap`.
+You should see the document content as a `Map`.
 
 Now, you know how to:
 

--- a/doc/1/getting-started/java/snippets/document-java.java
+++ b/doc/1/getting-started/java/snippets/document-java.java
@@ -1,8 +1,6 @@
 import io.kuzzle.sdk.*;
 import io.kuzzle.sdk.protocol.WebSocket;
 
-;
-
 public class SnippetTest {
   private static Kuzzle kuzzle;
 

--- a/doc/1/getting-started/java/snippets/document-java.java
+++ b/doc/1/getting-started/java/snippets/document-java.java
@@ -1,5 +1,6 @@
 import io.kuzzle.sdk.*;
 import io.kuzzle.sdk.protocol.WebSocket;
+import java.util.*;
 
 public class SnippetTest {
   private static Kuzzle kuzzle;

--- a/doc/1/getting-started/java/snippets/document-java.java
+++ b/doc/1/getting-started/java/snippets/document-java.java
@@ -1,7 +1,7 @@
 import io.kuzzle.sdk.*;
 import io.kuzzle.sdk.protocol.WebSocket;
 
-import java.util.concurrent.ConcurrentHashMap;
+;
 
 public class SnippetTest {
   private static Kuzzle kuzzle;
@@ -25,7 +25,7 @@ public class SnippetTest {
     }
 
     // New document content
-    ConcurrentHashMap<String, Object> content = new ConcurrentHashMap<>();
+    Map<String, Object> content = new HashMap<>();
     content.put("name", "John");
     content.put("birthday", "1995-11-27");
     content.put("license", "B");

--- a/doc/1/getting-started/java/snippets/firstconnection-java.java
+++ b/doc/1/getting-started/java/snippets/firstconnection-java.java
@@ -1,7 +1,7 @@
 import io.kuzzle.sdk.*;
 import io.kuzzle.sdk.protocol.WebSocket;
 
-import java.util.concurrent.ConcurrentHashMap;
+;
 
 public class SnippetTest {
   private static Kuzzle kuzzle;

--- a/doc/1/getting-started/java/snippets/firstconnection-java.java
+++ b/doc/1/getting-started/java/snippets/firstconnection-java.java
@@ -1,8 +1,6 @@
 import io.kuzzle.sdk.*;
 import io.kuzzle.sdk.protocol.WebSocket;
 
-;
-
 public class SnippetTest {
   private static Kuzzle kuzzle;
 

--- a/doc/1/getting-started/java/snippets/firstconnection-java.java
+++ b/doc/1/getting-started/java/snippets/firstconnection-java.java
@@ -1,5 +1,6 @@
 import io.kuzzle.sdk.*;
 import io.kuzzle.sdk.protocol.WebSocket;
+import java.util.*;
 
 public class SnippetTest {
   private static Kuzzle kuzzle;

--- a/doc/1/getting-started/java/snippets/realtime-java.java
+++ b/doc/1/getting-started/java/snippets/realtime-java.java
@@ -1,8 +1,6 @@
 import io.kuzzle.sdk.*;
 import io.kuzzle.sdk.protocol.WebSocket;
 
-;
-
 public class SnippetTest {
   private static Kuzzle kuzzle;
 

--- a/doc/1/getting-started/java/snippets/realtime-java.java
+++ b/doc/1/getting-started/java/snippets/realtime-java.java
@@ -1,5 +1,6 @@
 import io.kuzzle.sdk.*;
 import io.kuzzle.sdk.protocol.WebSocket;
+import java.util.*;
 
 public class SnippetTest {
   private static Kuzzle kuzzle;

--- a/doc/1/getting-started/java/snippets/realtime-java.java
+++ b/doc/1/getting-started/java/snippets/realtime-java.java
@@ -1,7 +1,7 @@
 import io.kuzzle.sdk.*;
 import io.kuzzle.sdk.protocol.WebSocket;
 
-import java.util.concurrent.ConcurrentHashMap;
+;
 
 public class SnippetTest {
   private static Kuzzle kuzzle;
@@ -25,8 +25,8 @@ public class SnippetTest {
     }
 
     // Subscribes to notifications for drivers having a "B" driver license.
-    ConcurrentHashMap<String, Object> filters = new ConcurrentHashMap<>();
-    ConcurrentHashMap<String, Object> equals = new ConcurrentHashMap<>();
+    Map<String, Object> filters = new HashMap<>();
+    Map<String, Object> equals = new HashMap<>();
     equals.put("license", "B");
     filters.put("equals", equals);
 
@@ -34,7 +34,7 @@ public class SnippetTest {
       // Sends the subscription
       kuzzle.getRealtimeController()
           .subscribe("nyc-open-data", "yellow-taxi", filters, notification -> {
-            ConcurrentHashMap<String, Object> content = ((ConcurrentHashMap<String, Object>)(notification.getResult()));
+            Map<String, Object> content = ((Map<String, Object>)(notification.getResult()));
             System.out.println("New created document notification: " + content);
             /*
             {
@@ -58,7 +58,7 @@ public class SnippetTest {
 
     // Writes a new document. This triggers a notification
     // sent to our subscription.
-    ConcurrentHashMap<String, Object> content = new ConcurrentHashMap<>();
+    Map<String, Object> content = new HashMap<>();
     content.put("name", "John");
     content.put("birthday", "1995-11-27");
     content.put("license", "B");

--- a/doc/1/getting-started/kotlin/index.md
+++ b/doc/1/getting-started/kotlin/index.md
@@ -151,7 +151,7 @@ New created document notification:
 
 ```
 
-You should see the document content as a `ConcurrentHashMap`.
+You should see the document content as a `Map`.
 
 Now, you know how to:
 

--- a/doc/1/getting-started/kotlin/snippets/document-kotlin.kt
+++ b/doc/1/getting-started/kotlin/snippets/document-kotlin.kt
@@ -1,7 +1,7 @@
 import io.kuzzle.sdk.*;
 import io.kuzzle.sdk.protocol.WebSocket;
 
-import java.util.concurrent.ConcurrentHashMap;
+;
 
 fun main() {
   // Creates a WebSocket connection.
@@ -18,7 +18,7 @@ fun main() {
 
   try {
     // New document content
-    val content: ConcurrentHashMap<String, Any?> = ConcurrentHashMap<String, Any?>().apply {
+    val content: Map<String, Any?> = Map<String, Any?>().apply {
       put("name", "John")
       put("birthday", "1995-11-27")
       put("license", "B")

--- a/doc/1/getting-started/kotlin/snippets/document-kotlin.kt
+++ b/doc/1/getting-started/kotlin/snippets/document-kotlin.kt
@@ -1,8 +1,6 @@
 import io.kuzzle.sdk.*;
 import io.kuzzle.sdk.protocol.WebSocket;
 
-;
-
 fun main() {
   // Creates a WebSocket connection.
   // Replace "kuzzle" with

--- a/doc/1/getting-started/kotlin/snippets/document-kotlin.kt
+++ b/doc/1/getting-started/kotlin/snippets/document-kotlin.kt
@@ -16,7 +16,7 @@ fun main() {
 
   try {
     // New document content
-    val content: Map<String, Any?> = Map<String, Any?>().apply {
+    val content: Map<String, Any?> = HashMap<String, Any?>().apply {
       put("name", "John")
       put("birthday", "1995-11-27")
       put("license", "B")

--- a/doc/1/getting-started/kotlin/snippets/firstconnection-kotlin.kt
+++ b/doc/1/getting-started/kotlin/snippets/firstconnection-kotlin.kt
@@ -1,8 +1,6 @@
 import io.kuzzle.sdk.*;
 import io.kuzzle.sdk.protocol.WebSocket;
 
-;
-
 fun main() {
   // Creates a WebSocket connection.
   // Replace "kuzzle" with

--- a/doc/1/getting-started/kotlin/snippets/firstconnection-kotlin.kt
+++ b/doc/1/getting-started/kotlin/snippets/firstconnection-kotlin.kt
@@ -1,7 +1,7 @@
 import io.kuzzle.sdk.*;
 import io.kuzzle.sdk.protocol.WebSocket;
 
-import java.util.concurrent.ConcurrentHashMap;
+;
 
 fun main() {
   // Creates a WebSocket connection.

--- a/doc/1/getting-started/kotlin/snippets/realtime-kotlin.kt
+++ b/doc/1/getting-started/kotlin/snippets/realtime-kotlin.kt
@@ -1,7 +1,7 @@
 import io.kuzzle.sdk.*;
 import io.kuzzle.sdk.protocol.WebSocket;
 
-import java.util.concurrent.ConcurrentHashMap;
+;
 
 fun main() {
   // Creates a WebSocket connection.
@@ -18,10 +18,10 @@ fun main() {
 
   try {
     // Subscribes to notifications for drivers having a "B" driver license.
-    val equals: ConcurrentHashMap<String, Any?> = ConcurrentHashMap<String, Any?>().apply {
+    val equals: Map<String, Any?> = Map<String, Any?>().apply {
       put("license", "B")
     }
-    val filters: ConcurrentHashMap<String, Any> = ConcurrentHashMap<String, Any>().apply {
+    val filters: Map<String, Any> = Map<String, Any>().apply {
       put("equals", equals)
     }
 
@@ -29,7 +29,7 @@ fun main() {
     kuzzle
         .realtimeController
         .subscribe("nyc-open-data", "yellow-taxi", filters) { notification ->
-          val content: ConcurrentHashMap<String, Any?> = notification.result as ConcurrentHashMap<String, Any?>
+          val content: Map<String, Any?> = notification.result as Map<String, Any?>
           println("New created document notification: " + content)  
           /*
             {
@@ -50,7 +50,7 @@ fun main() {
 
     // Writes a new document. This triggers a notification
     // sent to our subscription.
-    val content: ConcurrentHashMap<String, Any?> = ConcurrentHashMap<String, Any?>().apply {
+    val content: Map<String, Any?> = Map<String, Any?>().apply {
       put("name", "John")
       put("birthday", "1995-11-27")
       put("license", "B")

--- a/doc/1/getting-started/kotlin/snippets/realtime-kotlin.kt
+++ b/doc/1/getting-started/kotlin/snippets/realtime-kotlin.kt
@@ -1,8 +1,6 @@
 import io.kuzzle.sdk.*;
 import io.kuzzle.sdk.protocol.WebSocket;
 
-;
-
 fun main() {
   // Creates a WebSocket connection.
   // Replace "kuzzle" with

--- a/doc/1/getting-started/kotlin/snippets/realtime-kotlin.kt
+++ b/doc/1/getting-started/kotlin/snippets/realtime-kotlin.kt
@@ -16,7 +16,7 @@ fun main() {
 
   try {
     // Subscribes to notifications for drivers having a "B" driver license.
-    val equals: Map<String, Any?> = Map<String, Any?>().apply {
+    val equals: Map<String, Any?> = HashMap<String, Any?>().apply {
       put("license", "B")
     }
     val filters: Map<String, Any> = Map<String, Any>().apply {
@@ -48,7 +48,7 @@ fun main() {
 
     // Writes a new document. This triggers a notification
     // sent to our subscription.
-    val content: Map<String, Any?> = Map<String, Any?>().apply {
+    val content: Map<String, Any?> = HashMap<String, Any?>().apply {
       put("name", "John")
       put("birthday", "1995-11-27")
       put("license", "B")

--- a/doc/1/getting-started/kotlin/snippets/realtime-kotlin.kt
+++ b/doc/1/getting-started/kotlin/snippets/realtime-kotlin.kt
@@ -19,7 +19,7 @@ fun main() {
     val equals: Map<String, Any?> = HashMap<String, Any?>().apply {
       put("license", "B")
     }
-    val filters: Map<String, Any> = Map<String, Any>().apply {
+    val filters: Map<String, Any> = HashMap<String, Any>().apply {
       put("equals", equals)
     }
 

--- a/src/main/kotlin/io/kuzzle/sdk/Kuzzle.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/Kuzzle.kt
@@ -17,7 +17,6 @@ import io.kuzzle.sdk.protocol.AbstractProtocol
 import io.kuzzle.sdk.protocol.ProtocolState
 import java.util.*
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ConcurrentHashMap
 import kotlin.collections.HashMap
 
 class Kuzzle {
@@ -55,7 +54,7 @@ class Kuzzle {
 
   private fun onMessageReceived(message: String?) {
     val response = Response().apply {
-      fromMap(JsonSerializer.deserialize(message) as ConcurrentHashMap<String?, Any?>)
+      fromMap(JsonSerializer.deserialize(message) as Map<String?, Any?>)
     }
 
     if (queries.size == 0 || (queries.size != 0 && (response.room == null || queries[response.room!!] == null))) {
@@ -94,7 +93,7 @@ class Kuzzle {
     protocol.disconnect()
   }
 
-  fun query(query: ConcurrentHashMap<String?, Any?>): CompletableFuture<Response> {
+  fun query(query: Map<String?, Any?>): CompletableFuture<Response> {
     if (protocol.state == ProtocolState.CLOSE) {
       throw NotConnectedException()
     }
@@ -115,7 +114,7 @@ class Kuzzle {
     }
 
     queries[requestId] = futureRes
-    query["requestId"] = requestId
+    queryMap["requestId"] = requestId
 
     if (!queryMap.containsKey("volatile") || queryMap.isNull("volatile")) {
       queryMap["volatile"] = KuzzleMap()
@@ -127,7 +126,7 @@ class Kuzzle {
 
     queryMap.getMap("volatile")!!["sdkName"] = sdkName
 
-    protocol.send(query)
+    protocol.send(queryMap)
 
     return futureRes
   }

--- a/src/main/kotlin/io/kuzzle/sdk/controllers/AuthController.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/controllers/AuthController.kt
@@ -5,12 +5,12 @@ import io.kuzzle.sdk.coreClasses.maps.KuzzleMap
 import io.kuzzle.sdk.coreClasses.responses.Response
 import java.util.*
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ConcurrentHashMap
+
 
 class AuthController(kuzzle: Kuzzle) : BaseController(kuzzle) {
 
   fun checkToken(
-      token: String): CompletableFuture<ConcurrentHashMap<String, Any?>> {
+      token: String): CompletableFuture<Map<String, Any?>> {
     val query = KuzzleMap().apply {
       put("controller", "auth")
       put("action", "checkToken")
@@ -20,12 +20,12 @@ class AuthController(kuzzle: Kuzzle) : BaseController(kuzzle) {
     }
     return kuzzle
         .query(query)
-        .thenApplyAsync { response -> response.result as ConcurrentHashMap<String, Any?> }
+        .thenApplyAsync { response -> response.result as Map<String, Any?> }
   }
 
   fun createMyCredentials(
       strategy: String,
-      credentials: ConcurrentHashMap<String, Any?>): CompletableFuture<ConcurrentHashMap<String, Any?>> {
+      credentials: Map<String, Any?>): CompletableFuture<Map<String, Any?>> {
     val query = KuzzleMap().apply {
       put("controller", "auth")
       put("action", "createMyCredentials")
@@ -34,7 +34,7 @@ class AuthController(kuzzle: Kuzzle) : BaseController(kuzzle) {
     }
     return kuzzle
         .query(query)
-        .thenApplyAsync { response -> response.result as ConcurrentHashMap<String, Any?> }
+        .thenApplyAsync { response -> response.result as Map<String, Any?> }
   }
 
   fun credentialsExist(strategy: String): CompletableFuture<Boolean> {
@@ -57,7 +57,7 @@ class AuthController(kuzzle: Kuzzle) : BaseController(kuzzle) {
     return kuzzle.query(query).thenRunAsync {}
   }
 
-  fun getCurrentUser(): CompletableFuture<ConcurrentHashMap<String, Any?>> {
+  fun getCurrentUser(): CompletableFuture<Map<String, Any?>> {
     val query = KuzzleMap().apply {
       put("controller", "auth")
       put("action", "getCurrentUser")
@@ -65,12 +65,12 @@ class AuthController(kuzzle: Kuzzle) : BaseController(kuzzle) {
     return kuzzle
         .query(query)
         .thenApplyAsync { response ->
-          response.result as ConcurrentHashMap<String, Any?>
+          response.result as Map<String, Any?>
         }
   }
 
   fun getMyCredentials(
-      strategy: String): CompletableFuture<ConcurrentHashMap<String, Any?>> {
+      strategy: String): CompletableFuture<Map<String, Any?>> {
     val query = KuzzleMap().apply {
       put("controller", "auth")
       put("action", "getMyCredentials")
@@ -79,7 +79,7 @@ class AuthController(kuzzle: Kuzzle) : BaseController(kuzzle) {
     return kuzzle
         .query(query)
         .thenApplyAsync { response ->
-          response.result as ConcurrentHashMap<String, Any?>
+          response.result as Map<String, Any?>
         }
   }
 
@@ -92,7 +92,7 @@ class AuthController(kuzzle: Kuzzle) : BaseController(kuzzle) {
         .query(query)
         .thenApplyAsync { response ->
           KuzzleMap
-              .from(response.result as ConcurrentHashMap<String?, Any?>)
+              .from(response.result as Map<String?, Any?>)
               .getArrayList("hits") as ArrayList<Any>
         }
   }
@@ -110,8 +110,8 @@ class AuthController(kuzzle: Kuzzle) : BaseController(kuzzle) {
   @JvmOverloads
   fun login(
       strategy: String,
-      credentials: ConcurrentHashMap<String, Any?>?,
-      expiresIn: String? = null): CompletableFuture<ConcurrentHashMap<String, Any?>> {
+      credentials: Map<String, Any?>?,
+      expiresIn: String? = null): CompletableFuture<Map<String, Any?>> {
     val query = KuzzleMap().apply {
       put("controller", "auth")
       put("action", "login")
@@ -123,14 +123,14 @@ class AuthController(kuzzle: Kuzzle) : BaseController(kuzzle) {
     }
     return kuzzle.query(query).thenApplyAsync { response ->
       val map: KuzzleMap = KuzzleMap
-          .from(response.result as ConcurrentHashMap<String?, Any?>)
+          .from(response.result as Map<String?, Any?>)
       kuzzle.authenticationToken = map.getString("jwt")
       if (map.getString("_id") != null) {
         kuzzle.protocol.trigger("loginAttempt", "true")
       } else {
         kuzzle.protocol.trigger("loginAttempt", "false")
       }
-      map as ConcurrentHashMap<String, Any?>
+      map as Map<String, Any?>
     }
   }
 
@@ -144,7 +144,7 @@ class AuthController(kuzzle: Kuzzle) : BaseController(kuzzle) {
 
   @JvmOverloads
   fun refreshToken(
-      expiresIn: String? = null): CompletableFuture<ConcurrentHashMap<String, Any?>> {
+      expiresIn: String? = null): CompletableFuture<Map<String, Any?>> {
     val query = KuzzleMap().apply {
       put("controller", "auth")
       put("action", "refreshToken")
@@ -152,15 +152,15 @@ class AuthController(kuzzle: Kuzzle) : BaseController(kuzzle) {
     }
     return kuzzle.query(query).thenApplyAsync { response ->
       val map: KuzzleMap = KuzzleMap
-          .from(response.result as ConcurrentHashMap<String?, Any?>)
+          .from(response.result as Map<String?, Any?>)
       kuzzle.authenticationToken = map.getString("jwt")
-      map as ConcurrentHashMap<String, Any?>
+      map as Map<String, Any?>
     }
   }
 
   fun updateMyCredentials(
       strategy: String,
-      credentials: ConcurrentHashMap<String, Any?>): CompletableFuture<ConcurrentHashMap<String, Any?>> {
+      credentials: Map<String, Any?>): CompletableFuture<Map<String, Any?>> {
     val query = KuzzleMap().apply {
       put("controller", "auth")
       put("action", "updateMyCredentials")
@@ -170,12 +170,12 @@ class AuthController(kuzzle: Kuzzle) : BaseController(kuzzle) {
     return kuzzle
         .query(query)
         .thenApplyAsync { response ->
-          response.result as ConcurrentHashMap<String, Any?>
+          response.result as Map<String, Any?>
         }
   }
 
   fun updateSelf(
-      content: ConcurrentHashMap<String, Any?>): CompletableFuture<ConcurrentHashMap<String, Any?>> {
+      content: Map<String, Any?>): CompletableFuture<Map<String, Any?>> {
     val query = KuzzleMap().apply {
       put("controller", "auth")
       put("action", "updateSelf")
@@ -184,12 +184,12 @@ class AuthController(kuzzle: Kuzzle) : BaseController(kuzzle) {
     return kuzzle
         .query(query)
         .thenApplyAsync { response ->
-          response.result as ConcurrentHashMap<String, Any?>
+          response.result as Map<String, Any?>
         }
   }
 
   fun validateMyCredentials(strategy: String,
-                            credentials: ConcurrentHashMap<String, Any?>): CompletableFuture<Boolean> {
+                            credentials: Map<String, Any?>): CompletableFuture<Boolean> {
     val query = KuzzleMap().apply {
       put("controller", "auth")
       put("action", "validateMyCredentials")

--- a/src/main/kotlin/io/kuzzle/sdk/controllers/BulkController.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/controllers/BulkController.kt
@@ -5,7 +5,7 @@ import io.kuzzle.sdk.coreClasses.maps.KuzzleMap
 import io.kuzzle.sdk.coreClasses.responses.Response
 import java.util.*
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ConcurrentHashMap
+
 import com.google.gson.internal.LazilyParsedNumber
 
 class BulkController(kuzzle: Kuzzle) : BaseController(kuzzle) {
@@ -14,54 +14,54 @@ class BulkController(kuzzle: Kuzzle) : BaseController(kuzzle) {
   fun deleteByQuery(
     index: String,
     collection: String,
-    searchQuery: ConcurrentHashMap<String, Any?>,
+    searchQuery: Map<String, Any?>,
     waitForRefresh: Boolean? = null): CompletableFuture<Int> {
     val query = KuzzleMap().apply {
       put("index", index)
       put("collection", collection)
       put("controller", "bulk")
       put("action", "deleteByQuery")
-      put("body", ConcurrentHashMap<String, Any?>().apply {
+      put("body", HashMap<String, Any?>().apply {
         put("query", searchQuery)
       })
       put("waitForRefresh", waitForRefresh)
     }
     return kuzzle
         .query(query)
-        .thenApplyAsync { response -> (response.result as ConcurrentHashMap<String?, Any?>)["deleted"] as Int}
+        .thenApplyAsync { response -> (response.result as Map<String?, Any?>)["deleted"] as Int}
   }
 
   fun importData(
       index: String,
       collection: String,
-      bulkData: ArrayList<ConcurrentHashMap<String, Any?>>): CompletableFuture<ConcurrentHashMap<String, Any?>> {
+      bulkData: ArrayList<Map<String, Any?>>): CompletableFuture<Map<String, Any?>> {
     val query = KuzzleMap().apply {
       put("index", index)
       put("collection", collection)
       put("controller", "bulk")
       put("action", "import")
-      put("body", ConcurrentHashMap<String, Any?>().apply {
+      put("body", HashMap<String, Any?>().apply {
         put("bulkData", bulkData)
       })
     }
     return kuzzle
         .query(query)
-        .thenApplyAsync { response -> (response.result as ConcurrentHashMap<String, Any?>) }
+        .thenApplyAsync { response -> (response.result as Map<String, Any?>) }
   }
 
 @JvmOverloads
   fun mWrite(
       index: String,
       collection: String,
-      documents: ArrayList<ConcurrentHashMap<String, Any?>>,
+      documents: ArrayList<Map<String, Any?>>,
       notify: Boolean? = null,
-      waitForRefresh: Boolean? = null): CompletableFuture<ConcurrentHashMap<String, Any?>> {
+      waitForRefresh: Boolean? = null): CompletableFuture<Map<String, Any?>> {
     val query = KuzzleMap().apply {
       put("index", index)
       put("collection", collection)
       put("controller", "bulk")
       put("action", "mWrite")
-      put("body", ConcurrentHashMap<String, Any?>().apply {
+      put("body", HashMap<String, Any?>().apply {
         put("documents", documents)
       })
       put("waitForRefresh", waitForRefresh)
@@ -69,17 +69,17 @@ class BulkController(kuzzle: Kuzzle) : BaseController(kuzzle) {
     }
     return kuzzle
         .query(query)
-        .thenApplyAsync { response -> (response.result as ConcurrentHashMap<String, Any?>) }
+        .thenApplyAsync { response -> (response.result as Map<String, Any?>) }
   }
 
 @JvmOverloads
   fun write(
       index: String,
       collection: String,
-      content: ConcurrentHashMap<String, Any?>,
+      content: Map<String, Any?>,
       id: String? = null,
       notify: Boolean? = null,
-      waitForRefresh: Boolean? = null): CompletableFuture<ConcurrentHashMap<String, Any?>> {
+      waitForRefresh: Boolean? = null): CompletableFuture<Map<String, Any?>> {
     val query = KuzzleMap().apply {
       put("index", index)
       put("collection", collection)
@@ -92,6 +92,6 @@ class BulkController(kuzzle: Kuzzle) : BaseController(kuzzle) {
     }
     return kuzzle
         .query(query)
-        .thenApplyAsync { response -> (response.result as ConcurrentHashMap<String, Any?>) }
+        .thenApplyAsync { response -> (response.result as Map<String, Any?>) }
   }
 }

--- a/src/main/kotlin/io/kuzzle/sdk/controllers/CollectionController.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/controllers/CollectionController.kt
@@ -3,9 +3,8 @@ package io.kuzzle.sdk.controllers
 import io.kuzzle.sdk.Kuzzle
 import io.kuzzle.sdk.coreClasses.maps.KuzzleMap
 import io.kuzzle.sdk.coreClasses.SearchResult
-import java.util.*
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ConcurrentHashMap
+
 
 class CollectionController(kuzzle: Kuzzle) : BaseController(kuzzle) {
 
@@ -13,7 +12,7 @@ class CollectionController(kuzzle: Kuzzle) : BaseController(kuzzle) {
   fun create(
       index: String,
       collection: String,
-      definition: ConcurrentHashMap<String, Any>? = null
+      definition: Map<String, Any>? = null
     ): CompletableFuture<Void> {
     return kuzzle
       .query(KuzzleMap().apply {
@@ -71,7 +70,7 @@ class CollectionController(kuzzle: Kuzzle) : BaseController(kuzzle) {
   fun getMapping(
     index: String,
     collection: String
-  ): CompletableFuture<ConcurrentHashMap<String, Any?>> {
+  ): CompletableFuture<Map<String, Any?>> {
   return kuzzle
     .query(KuzzleMap().apply {
       put("controller", "collection")
@@ -79,13 +78,13 @@ class CollectionController(kuzzle: Kuzzle) : BaseController(kuzzle) {
       put("index", index)
       put("collection", collection)
     })
-    .thenApplyAsync { response -> response.result as ConcurrentHashMap<String, Any?> }
+    .thenApplyAsync { response -> response.result as Map<String, Any?> }
 }
 
 fun getSpecifications(
     index: String,
     collection: String
-  ): CompletableFuture<ConcurrentHashMap<String, Any?>> {
+  ): CompletableFuture<Map<String, Any?>> {
   return kuzzle
     .query(KuzzleMap().apply {
       put("controller", "collection")
@@ -93,17 +92,17 @@ fun getSpecifications(
       put("index", index)
       put("collection", collection)
     })
-    .thenApplyAsync { response -> response.result as ConcurrentHashMap<String, Any?> }
+    .thenApplyAsync { response -> response.result as Map<String, Any?> }
 }
 
-  fun list(index: String): CompletableFuture<ConcurrentHashMap<String, Any?>> {
+  fun list(index: String): CompletableFuture<Map<String, Any?>> {
     return kuzzle
         .query(KuzzleMap().apply {
           put("controller", "collection")
           put("action", "list")
           put("index", index)
         })
-        .thenApplyAsync { response -> response.result as ConcurrentHashMap<String, Any?> }
+        .thenApplyAsync { response -> response.result as Map<String, Any?> }
   }
 
   fun refresh(
@@ -122,7 +121,7 @@ fun getSpecifications(
 
   @JvmOverloads
   fun searchSpecifications(
-    searchQuery: ConcurrentHashMap<String, Any?>,
+    searchQuery: Map<String, Any?>,
     scroll: String? = null,
     from: Int = 0,
     size: Int? = null
@@ -157,7 +156,7 @@ fun getSpecifications(
   fun update(
     index: String,
     collection: String,
-    definition: ConcurrentHashMap<String, Any?>
+    definition: Map<String, Any?>
   ): CompletableFuture<Void> {
     return kuzzle
         .query(KuzzleMap().apply {
@@ -173,8 +172,8 @@ fun getSpecifications(
   fun updateSpecifications(
     index: String,
     collection: String,
-    definition: ConcurrentHashMap<String, Any?>
-  ): CompletableFuture<ConcurrentHashMap<String, Any?>> {
+    definition: Map<String, Any?>
+  ): CompletableFuture<Map<String, Any?>> {
     return kuzzle
         .query(KuzzleMap().apply {
           put("controller", "collection")
@@ -183,14 +182,14 @@ fun getSpecifications(
           put("collection", collection)
           put("body", definition)
         })
-        .thenApplyAsync { response -> response.result as ConcurrentHashMap<String, Any?> }
+        .thenApplyAsync { response -> response.result as Map<String, Any?> }
   }
 
   fun validateSpecifications(
     index: String,
     collection: String,
-    specifications: ConcurrentHashMap<String, Any>?
-  ): CompletableFuture<ConcurrentHashMap<String, Any?>> {
+    specifications: Map<String, Any>?
+  ): CompletableFuture<Map<String, Any?>> {
     return kuzzle
         .query(KuzzleMap().apply {
           put("controller", "collection")
@@ -199,6 +198,6 @@ fun getSpecifications(
           put("collection", collection)
           put("body", specifications)
         })
-        .thenApplyAsync { response -> response.result as ConcurrentHashMap<String, Any?> }
+        .thenApplyAsync { response -> response.result as Map<String, Any?> }
   }
 }

--- a/src/main/kotlin/io/kuzzle/sdk/controllers/DocumentController.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/controllers/DocumentController.kt
@@ -4,9 +4,7 @@ import com.google.gson.internal.LazilyParsedNumber
 import io.kuzzle.sdk.Kuzzle
 import io.kuzzle.sdk.coreClasses.SearchResult
 import io.kuzzle.sdk.coreClasses.maps.KuzzleMap
-import java.util.*
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ConcurrentHashMap
 
 class DocumentController(kuzzle: Kuzzle) : BaseController(kuzzle) {
 
@@ -14,7 +12,7 @@ class DocumentController(kuzzle: Kuzzle) : BaseController(kuzzle) {
   fun count(
       index: String,
       collection: String,
-      searchQuery: ConcurrentHashMap<String, Any?> = ConcurrentHashMap<String, Any?>()): CompletableFuture<Int> {
+      searchQuery: Map<String, Any?> = mapOf()): CompletableFuture<Int> {
     val query = KuzzleMap().apply {
       put("index", index)
       put("collection", collection)
@@ -24,16 +22,16 @@ class DocumentController(kuzzle: Kuzzle) : BaseController(kuzzle) {
     }
     return kuzzle
         .query(query)
-        .thenApplyAsync { response -> ((response.result as ConcurrentHashMap<String, Any?>)["count"] as LazilyParsedNumber).toInt() }
+        .thenApplyAsync { response -> ((response.result as Map<String, Any?>)["count"] as LazilyParsedNumber).toInt() }
   }
 
   @JvmOverloads
   fun create(
       index: String,
       collection: String,
-      document: ConcurrentHashMap<String, Any?>,
+      document: Map<String, Any?>,
       id: String? = null,
-      waitForRefresh: Boolean? = null): CompletableFuture<ConcurrentHashMap<String, Any?>> {
+      waitForRefresh: Boolean? = null): CompletableFuture<Map<String, Any?>> {
     val query = KuzzleMap().apply {
       put("index", index)
       put("collection", collection)
@@ -45,7 +43,7 @@ class DocumentController(kuzzle: Kuzzle) : BaseController(kuzzle) {
     }
     return kuzzle
         .query(query)
-        .thenApplyAsync { response -> response.result as ConcurrentHashMap<String, Any?> }
+        .thenApplyAsync { response -> response.result as Map<String, Any?> }
   }
 
   @JvmOverloads
@@ -53,8 +51,8 @@ class DocumentController(kuzzle: Kuzzle) : BaseController(kuzzle) {
       index: String,
       collection: String,
       id: String,
-      document: ConcurrentHashMap<String, Any?>,
-      waitForRefresh: Boolean? = null): CompletableFuture<ConcurrentHashMap<String, Any?>> {
+      document: Map<String, Any?>,
+      waitForRefresh: Boolean? = null): CompletableFuture<Map<String, Any?>> {
     val query = KuzzleMap().apply {
       put("index", index)
       put("collection", collection)
@@ -66,7 +64,7 @@ class DocumentController(kuzzle: Kuzzle) : BaseController(kuzzle) {
     }
     return kuzzle
         .query(query)
-        .thenApplyAsync { response -> response.result as ConcurrentHashMap<String, Any?> }
+        .thenApplyAsync { response -> response.result as Map<String, Any?> }
   }
 
   @JvmOverloads
@@ -74,7 +72,7 @@ class DocumentController(kuzzle: Kuzzle) : BaseController(kuzzle) {
       index: String,
       collection: String,
       id: String?,
-      waitForRefresh: Boolean? = null): CompletableFuture<ConcurrentHashMap<String, Any?>> {
+      waitForRefresh: Boolean? = null): CompletableFuture<Map<String, Any?>> {
     val query = KuzzleMap().apply {
       put("index", index)
       put("collection", collection)
@@ -86,14 +84,14 @@ class DocumentController(kuzzle: Kuzzle) : BaseController(kuzzle) {
 
     return kuzzle
         .query(query)
-        .thenApplyAsync { response -> response.result as ConcurrentHashMap<String, Any?> }
+        .thenApplyAsync { response -> response.result as Map<String, Any?> }
   }
 
   @JvmOverloads
   fun deleteByQuery(
       index: String,
       collection: String,
-      searchQuery: ConcurrentHashMap<String, Any?>,
+      searchQuery: Map<String, Any?>,
       waitForRefresh: Boolean? = null): CompletableFuture<ArrayList<String>> {
     val query = KuzzleMap().apply {
       put("index", index)
@@ -105,7 +103,7 @@ class DocumentController(kuzzle: Kuzzle) : BaseController(kuzzle) {
     }
     return kuzzle
         .query(query)
-        .thenApplyAsync { response -> (response.result as ConcurrentHashMap<String?, Any?>)["ids"] as ArrayList<String> }
+        .thenApplyAsync { response -> (response.result as Map<String?, Any?>)["ids"] as ArrayList<String> }
   }
 
   fun exists(
@@ -127,7 +125,7 @@ class DocumentController(kuzzle: Kuzzle) : BaseController(kuzzle) {
   fun get(
       index: String,
       collection: String,
-      id: String): CompletableFuture<ConcurrentHashMap<String, Any?>> {
+      id: String): CompletableFuture<Map<String, Any?>> {
     val query = KuzzleMap().apply {
       put("index", index)
       put("collection", collection)
@@ -137,15 +135,15 @@ class DocumentController(kuzzle: Kuzzle) : BaseController(kuzzle) {
     }
     return kuzzle
         .query(query)
-        .thenApplyAsync { response -> response.result as ConcurrentHashMap<String, Any?> }
+        .thenApplyAsync { response -> response.result as Map<String, Any?> }
   }
 
   @JvmOverloads
   fun mCreate(
       index: String,
       collection: String,
-      documents: ArrayList<ConcurrentHashMap<String, Any?>>,
-      waitForRefresh: Boolean? = null): CompletableFuture<ConcurrentHashMap<String, ArrayList<Any>>> {
+      documents: ArrayList<Map<String, Any?>>,
+      waitForRefresh: Boolean? = null): CompletableFuture<Map<String, ArrayList<Any>>> {
     val query = KuzzleMap().apply {
       put("index", index)
       put("collection", collection)
@@ -157,15 +155,15 @@ class DocumentController(kuzzle: Kuzzle) : BaseController(kuzzle) {
 
     return kuzzle
         .query(query)
-        .thenApplyAsync { response -> response.result as ConcurrentHashMap<String, ArrayList<Any>> }
+        .thenApplyAsync { response -> response.result as Map<String, ArrayList<Any>> }
   }
 
   @JvmOverloads
   fun mCreateOrReplace(
       index: String,
       collection: String,
-      documents: ArrayList<ConcurrentHashMap<String, Any?>>,
-      waitForRefresh: Boolean? = null): CompletableFuture<ConcurrentHashMap<String, ArrayList<Any>>> {
+      documents: ArrayList<Map<String, Any?>>,
+      waitForRefresh: Boolean? = null): CompletableFuture<Map<String, ArrayList<Any>>> {
     val query = KuzzleMap().apply {
       put("index", index)
       put("collection", collection)
@@ -176,7 +174,7 @@ class DocumentController(kuzzle: Kuzzle) : BaseController(kuzzle) {
     }
     return kuzzle
         .query(query)
-        .thenApplyAsync { response -> response.result as ConcurrentHashMap<String, ArrayList<Any>> }
+        .thenApplyAsync { response -> response.result as Map<String, ArrayList<Any>> }
   }
 
   @JvmOverloads
@@ -184,7 +182,7 @@ class DocumentController(kuzzle: Kuzzle) : BaseController(kuzzle) {
       index: String,
       collection: String,
       ids: ArrayList<String>,
-      waitForRefresh: Boolean? = null): CompletableFuture<ConcurrentHashMap<String, ArrayList<Any>>> {
+      waitForRefresh: Boolean? = null): CompletableFuture<Map<String, ArrayList<Any>>> {
     val query = KuzzleMap().apply {
       put("index", index)
       put("collection", collection)
@@ -196,13 +194,13 @@ class DocumentController(kuzzle: Kuzzle) : BaseController(kuzzle) {
 
     return kuzzle
         .query(query)
-        .thenApplyAsync { response -> response.result as ConcurrentHashMap<String, ArrayList<Any>> }
+        .thenApplyAsync { response -> response.result as Map<String, ArrayList<Any>> }
   }
 
   fun mGet(
       index: String,
       collection: String,
-      ids: ArrayList<String>): CompletableFuture<ConcurrentHashMap<String, ArrayList<Any>>> {
+      ids: ArrayList<String>): CompletableFuture<Map<String, ArrayList<Any>>> {
     val query = KuzzleMap().apply {
       put("index", index)
       put("collection", collection)
@@ -213,15 +211,15 @@ class DocumentController(kuzzle: Kuzzle) : BaseController(kuzzle) {
 
     return kuzzle
         .query(query)
-        .thenApplyAsync { response -> response.result as ConcurrentHashMap<String, ArrayList<Any>> }
+        .thenApplyAsync { response -> response.result as Map<String, ArrayList<Any>> }
   }
 
   @JvmOverloads
   fun mReplace(
       index: String,
       collection: String,
-      documents: ArrayList<ConcurrentHashMap<String, Any?>>,
-      waitForRefresh: Boolean? = null): CompletableFuture<ConcurrentHashMap<String, ArrayList<Any>?>> {
+      documents: ArrayList<Map<String, Any?>>,
+      waitForRefresh: Boolean? = null): CompletableFuture<Map<String, ArrayList<Any>?>> {
     val query = KuzzleMap().apply {
       put("index", index)
       put("collection", collection)
@@ -232,16 +230,16 @@ class DocumentController(kuzzle: Kuzzle) : BaseController(kuzzle) {
     }
     return kuzzle
         .query(query)
-        .thenApplyAsync { response -> response.result as ConcurrentHashMap<String, ArrayList<Any>?> }
+        .thenApplyAsync { response -> response.result as Map<String, ArrayList<Any>?> }
   }
 
   @JvmOverloads
   fun mUpdate(
       index: String,
       collection: String,
-      documents: ArrayList<ConcurrentHashMap<String, Any?>?>,
+      documents: ArrayList<Map<String, Any?>?>,
       waitForRefresh: Boolean? = null,
-      retryOnConflict: Int? = null): CompletableFuture<ConcurrentHashMap<String, ArrayList<Any>?>> {
+      retryOnConflict: Int? = null): CompletableFuture<Map<String, ArrayList<Any>?>> {
     val query = KuzzleMap().apply {
       put("index", index)
       put("collection", collection)
@@ -253,7 +251,7 @@ class DocumentController(kuzzle: Kuzzle) : BaseController(kuzzle) {
     }
     return kuzzle
         .query(query)
-        .thenApplyAsync { response -> response.result as ConcurrentHashMap<String, ArrayList<Any>?> }
+        .thenApplyAsync { response -> response.result as Map<String, ArrayList<Any>?> }
   }
 
   @JvmOverloads
@@ -261,8 +259,8 @@ class DocumentController(kuzzle: Kuzzle) : BaseController(kuzzle) {
       index: String,
       collection: String,
       id: String?,
-      document: ConcurrentHashMap<String, Any?>,
-      waitForRefresh: Boolean? = null): CompletableFuture<ConcurrentHashMap<String, Any?>> {
+      document: Map<String, Any?>,
+      waitForRefresh: Boolean? = null): CompletableFuture<Map<String, Any?>> {
     val query = KuzzleMap().apply {
       put("index", index)
       put("collection", collection)
@@ -275,14 +273,14 @@ class DocumentController(kuzzle: Kuzzle) : BaseController(kuzzle) {
 
     return kuzzle
         .query(query)
-        .thenApplyAsync { response -> response.result as ConcurrentHashMap<String, Any?> }
+        .thenApplyAsync { response -> response.result as Map<String, Any?> }
   }
 
   @JvmOverloads
   fun search(
       index: String,
       collection: String,
-      searchQuery: ConcurrentHashMap<String, Any?>,
+      searchQuery: Map<String, Any?>,
       scroll: String? = null,
       size: Int? = null,
       from: Int = 0): CompletableFuture<SearchResult> {
@@ -308,7 +306,7 @@ class DocumentController(kuzzle: Kuzzle) : BaseController(kuzzle) {
   fun search(
       index: String,
       collection: String,
-      searchQuery: ConcurrentHashMap<String, Any?>,
+      searchQuery: Map<String, Any?>,
       size: Int? = null,
       from: Int = 0): CompletableFuture<SearchResult> {
 
@@ -320,10 +318,10 @@ class DocumentController(kuzzle: Kuzzle) : BaseController(kuzzle) {
       index: String,
       collection: String,
       id: String?,
-      document: ConcurrentHashMap<String, Any?>,
+      document: Map<String, Any?>,
       waitForRefresh: Boolean? = null,
       retryOnConflict: Int? = null,
-      source: Boolean? = null): CompletableFuture<ConcurrentHashMap<String, Any?>> {
+      source: Boolean? = null): CompletableFuture<Map<String, Any?>> {
     val query = KuzzleMap().apply {
       put("index", index)
       put("collection", collection)
@@ -337,18 +335,18 @@ class DocumentController(kuzzle: Kuzzle) : BaseController(kuzzle) {
     }
     return kuzzle
         .query(query)
-        .thenApplyAsync { response -> response.result as ConcurrentHashMap<String, Any?> }
+        .thenApplyAsync { response -> response.result as Map<String, Any?> }
   }
 
   @JvmOverloads
   fun updateByQuery(
       index: String,
       collection: String,
-      searchQuery: ConcurrentHashMap<String, Any?>,
-      changes: ConcurrentHashMap<String, Any?>,
+      searchQuery: Map<String, Any?>,
+      changes: Map<String, Any?>,
       waitForRefresh: Boolean? = null,
       retryOnConflict: Int? = null,
-      source: Boolean? = null): CompletableFuture<ConcurrentHashMap<String, ArrayList<Any?>>> {
+      source: Boolean? = null): CompletableFuture<Map<String, ArrayList<Any?>>> {
     val query = KuzzleMap().apply {
       put("index", index)
       put("collection", collection)
@@ -365,13 +363,13 @@ class DocumentController(kuzzle: Kuzzle) : BaseController(kuzzle) {
 
     return kuzzle
         .query(query)
-        .thenApplyAsync { response -> response.result as ConcurrentHashMap<String, ArrayList<Any?>> }
+        .thenApplyAsync { response -> response.result as Map<String, ArrayList<Any?>> }
   }
 
   fun validate(
       index: String,
       collection: String,
-      document: ConcurrentHashMap<String, Any?>): CompletableFuture<Boolean> {
+      document: Map<String, Any?>): CompletableFuture<Boolean> {
     val query = KuzzleMap().apply {
       put("index", index)
       put("collection", collection)
@@ -381,6 +379,6 @@ class DocumentController(kuzzle: Kuzzle) : BaseController(kuzzle) {
     }
     return kuzzle
         .query(query)
-        .thenApplyAsync { response -> (response.result as ConcurrentHashMap<*, *>)["valid"] as Boolean }
+        .thenApplyAsync { response -> (response.result as Map<*, *>)["valid"] as Boolean }
   }
 }

--- a/src/main/kotlin/io/kuzzle/sdk/controllers/ServerController.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/controllers/ServerController.kt
@@ -4,7 +4,7 @@ import io.kuzzle.sdk.Kuzzle
 import io.kuzzle.sdk.coreClasses.maps.KuzzleMap
 import java.util.Date
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ConcurrentHashMap
+
 
 class ServerController(kuzzle: Kuzzle) : BaseController(kuzzle) {
 
@@ -18,12 +18,12 @@ class ServerController(kuzzle: Kuzzle) : BaseController(kuzzle) {
         .query(query)
         .thenApplyAsync { response ->
           KuzzleMap
-              .from(response.result as ConcurrentHashMap<String?, Any?>)
+              .from(response.result as Map<String?, Any?>)
               .getBoolean("exists")
         }
   }
 
-  fun getAllStats(): CompletableFuture<ConcurrentHashMap<String, Any?>> {
+  fun getAllStats(): CompletableFuture<Map<String, Any?>> {
     val query = KuzzleMap().apply {
       put("controller", "server")
       put("action", "getAllStats")
@@ -31,11 +31,11 @@ class ServerController(kuzzle: Kuzzle) : BaseController(kuzzle) {
     return kuzzle
         .query(query)
         .thenApplyAsync { response ->
-          response.result as ConcurrentHashMap<String, Any?>
+          response.result as Map<String, Any?>
         }
   }
 
-  fun getConfig(): CompletableFuture<ConcurrentHashMap<String, Any?>> {
+  fun getConfig(): CompletableFuture<Map<String, Any?>> {
     val query = KuzzleMap().apply {
       put("controller", "server")
       put("action", "getConfig")
@@ -43,11 +43,11 @@ class ServerController(kuzzle: Kuzzle) : BaseController(kuzzle) {
     return kuzzle
         .query(query)
         .thenApplyAsync { response ->
-          response.result as ConcurrentHashMap<String, Any?>
+          response.result as Map<String, Any?>
         }
   }
 
-  fun getLastStats(): CompletableFuture<ConcurrentHashMap<String, Any?>> {
+  fun getLastStats(): CompletableFuture<Map<String, Any?>> {
     val query = KuzzleMap().apply {
       put("controller", "server")
       put("action", "getLastStats")
@@ -55,11 +55,11 @@ class ServerController(kuzzle: Kuzzle) : BaseController(kuzzle) {
     return kuzzle
         .query(query)
         .thenApplyAsync { response ->
-          response.result as ConcurrentHashMap<String, Any?>
+          response.result as Map<String, Any?>
         }
   }
 
-  fun getStats(startTime: Date, stopTime: Date): CompletableFuture<ConcurrentHashMap<String, Any?>> {
+  fun getStats(startTime: Date, stopTime: Date): CompletableFuture<Map<String, Any?>> {
     val query = KuzzleMap().apply {
       put("controller", "server")
       put("action", "getStats")
@@ -69,11 +69,11 @@ class ServerController(kuzzle: Kuzzle) : BaseController(kuzzle) {
     return kuzzle
         .query(query)
         .thenApplyAsync { response ->
-          response.result as ConcurrentHashMap<String, Any?>
+          response.result as Map<String, Any?>
         }
   }
 
-  fun info(): CompletableFuture<ConcurrentHashMap<String, Any?>> {
+  fun info(): CompletableFuture<Map<String, Any?>> {
     val query = KuzzleMap().apply {
       put("controller", "server")
       put("action", "info")
@@ -81,7 +81,7 @@ class ServerController(kuzzle: Kuzzle) : BaseController(kuzzle) {
     return kuzzle
         .query(query)
         .thenApplyAsync { response ->
-          response.result as ConcurrentHashMap<String, Any?>
+          response.result as Map<String, Any?>
         }
   }
 
@@ -93,7 +93,7 @@ class ServerController(kuzzle: Kuzzle) : BaseController(kuzzle) {
           put("action", "now")
         })
         .thenApplyAsync { response ->
-          val date = ((response.result as ConcurrentHashMap<String, Any>)["now"]).toString().toLong()
+          val date = ((response.result as Map<String, Any>)["now"]).toString().toLong()
           Date(date)
       }
   }

--- a/src/main/kotlin/io/kuzzle/sdk/coreClasses/SearchResult.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/coreClasses/SearchResult.kt
@@ -2,23 +2,23 @@ package io.kuzzle.sdk.coreClasses
 
 import com.google.gson.internal.LazilyParsedNumber
 import io.kuzzle.sdk.Kuzzle
+import io.kuzzle.sdk.coreClasses.maps.KuzzleMap
 import io.kuzzle.sdk.coreClasses.responses.Response
-import java.util.*
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ConcurrentHashMap
+
 import java.util.function.Function
 
 class SearchResult {
   private var scroll: String? = null
   private var from: Int = 0
   private var size: Int? = null
-  private var request: ConcurrentHashMap<String?, Any?>? = null
+  private var request: Map<String?, Any?>? = null
   private val scrollAction = "scroll"
   private var kuzzle: Kuzzle? = null
 
-  var aggregations: ConcurrentHashMap<String, Any>? = null
+  var aggregations: Map<String, Any>? = null
   @JvmField
-  public var hits: ArrayList<ConcurrentHashMap<String, Any>> = ArrayList<ConcurrentHashMap<String, Any>>()
+  public var hits: ArrayList<Map<String, Any>> = ArrayList<Map<String, Any>>()
   @JvmField
   public var total: Int = 0
   @JvmField
@@ -28,48 +28,48 @@ class SearchResult {
   @JvmOverloads
   constructor(
       kuzzle: Kuzzle?,
-      request: ConcurrentHashMap<String?, Any?>?,
+      request: KuzzleMap,
       scroll: String? = null,
       from: Int = 0,
       size: Int? = null,
       response: Response,
       previouslyFetched: Int? = null) {
-    val _response: ConcurrentHashMap<String?, Any?> = response.toMap()
+    val _response: Map<String?, Any?> = response.toMap()
     this.kuzzle = kuzzle
     this.scroll = scroll
     this.from = from
     this.size = size
     this.request = request
-    this.aggregations = (_response["result"] as ConcurrentHashMap<*, *>)["aggregations"] as ConcurrentHashMap<String, Any>?
-    this.hits = (_response["result"] as ConcurrentHashMap<*, *>)["hits"] as ArrayList<ConcurrentHashMap<String, Any>>
-    this.total = ((_response["result"] as ConcurrentHashMap<*, *>)["total"] as LazilyParsedNumber?)!!.toInt()
+    this.aggregations = (_response["result"] as Map<*, *>)["aggregations"] as Map<String, Any>?
+    this.hits = (_response["result"] as Map<*, *>)["hits"] as ArrayList<Map<String, Any>>
+    this.total = ((_response["result"] as Map<*, *>)["total"] as LazilyParsedNumber?)!!.toInt()
     this.fetched = hits!!.size
     if (previouslyFetched != null) {
       this.fetched += previouslyFetched
     }
-    scrollId = (_response["result"] as ConcurrentHashMap<*, *>)["scrollId"] as String?
+    scrollId = (_response["result"] as Map<*, *>)["scrollId"] as String?
   }
 
-  private fun getScrollRequest(): ConcurrentHashMap<String?, Any?>? {
-    val obj = ConcurrentHashMap<String?, Any?>()
+  private fun getScrollRequest(): Map<String?, Any?>? {
+    val obj = HashMap<String?, Any?>()
     obj["controller"] = request!!["controller"]!!
     obj["action"] = scrollAction
     obj["scrollId"] = scrollId!!
     return obj
   }
 
-  private fun getSearchAfterRequest(): ConcurrentHashMap<String?, Any?>? {
+  private fun getSearchAfterRequest(): Map<String?, Any?>? {
     val nextRequest = request
     val lastItem = hits!![hits!!.size]
     val searchAfter = ArrayList<Any?>()
-    val sort = (request!!["body"] as ConcurrentHashMap<*, *>)["sort"] as ArrayList<Any>?
-    (request!!["body"] as ConcurrentHashMap<String?, Any?>)["search_after"] = searchAfter
+    val sort = (request!!["body"] as Map<*, *>)["sort"] as ArrayList<Any>?
+    (request!!["body"] as HashMap<String?, Any?>)["search_after"] = searchAfter
     for (value in sort!!) {
-      var key: String = (value as? String)?.toString() ?: (value as ConcurrentHashMap<*, *>)["First"].toString()
+      var key: String = (value as? String)?.toString() ?: (value as Map<*, *>)["First"].toString()
       if (key == "_uid") {
         searchAfter.add(request!!["collection"].toString() + "#" + lastItem["_id"].toString())
       } else {
-        val _source = lastItem["_source"] as ConcurrentHashMap<*, *>?
+        val _source = lastItem["_source"] as Map<*, *>?
         searchAfter.add(_source!![key])
       }
     }
@@ -78,11 +78,11 @@ class SearchResult {
 
   operator fun next(): CompletableFuture<SearchResult?> {
     if (fetched >= total) return CompletableFuture.completedFuture(null)
-    var nextRequest: ConcurrentHashMap<String?, Any?>? = null
+    var nextRequest: Map<String?, Any?>? = null
     if (scrollId != null) {
       nextRequest = getScrollRequest()
     } else if (size != null
-        && (request!!["body"] as ConcurrentHashMap<*, *>)["sort"] != null) {
+        && (request!!["body"] as Map<*, *>)["sort"] != null) {
       nextRequest = getSearchAfterRequest()
     } else if (size != null) {
       if (from != null && from >= total) {
@@ -94,9 +94,9 @@ class SearchResult {
     if (nextRequest == null) {
       return CompletableFuture.completedFuture(null)
     }
-    val request: ConcurrentHashMap<String?, Any?> = nextRequest
+    val request: Map<String?, Any?> = nextRequest
     return kuzzle!!.query(nextRequest)
         .thenApplyAsync(
-            Function { response: Response -> SearchResult(kuzzle, request, scroll, from, size, response, fetched) })
+            Function { response: Response -> SearchResult(kuzzle, KuzzleMap.from(request), scroll, from, size, response, fetched) })
   }
 }

--- a/src/main/kotlin/io/kuzzle/sdk/coreClasses/exceptions/KuzzleExceptionCode.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/coreClasses/exceptions/KuzzleExceptionCode.kt
@@ -3,7 +3,7 @@ package io.kuzzle.sdk.coreClasses.exceptions
 enum class KuzzleExceptionCode {
   MISSING_REQUESTID(0, "Missing field requestId"), MISSING_QUERY(400, "You must provide a query"), NOT_CONNECTED(500, "Not connected."), CONNECTION_LOST(500, "Connection lost"), WRONG_VOLATILE_TYPE(
       400,
-      "Volatile data must be a ConcurrentHashMap<String, Object>");
+      "Volatile data must be a Map<String, Object>");
 
   val code: Int
   val message: String?

--- a/src/main/kotlin/io/kuzzle/sdk/coreClasses/json/ConcurrentHashMapTypeAdapter.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/coreClasses/json/ConcurrentHashMapTypeAdapter.kt
@@ -9,11 +9,11 @@ import com.google.gson.stream.JsonWriter
 import io.kuzzle.sdk.coreClasses.maps.KuzzleMap
 import java.io.IOException
 import java.util.*
-import java.util.concurrent.ConcurrentHashMap
 
-class ConcurrentHashMapTypeAdapter : TypeAdapter<ConcurrentHashMap<String?, Any?>?>() {
+
+class MapTypeAdapter : TypeAdapter<Map<String?, Any?>?>() {
   @Throws(IOException::class)
-  override fun write(out: JsonWriter, map: ConcurrentHashMap<String?, Any?>?) {
+  override fun write(out: JsonWriter, map: Map<String?, Any?>?) {
     if (map == null) {
       out.nullValue()
     } else {
@@ -29,7 +29,7 @@ class ConcurrentHashMapTypeAdapter : TypeAdapter<ConcurrentHashMap<String?, Any?
   }
 
   @Throws(IOException::class)
-  override fun read(`in`: JsonReader): ConcurrentHashMap<String?, Any?>? {
+  override fun read(`in`: JsonReader): Map<String?, Any?>? {
     val peek = `in`.peek()
     if (peek == JsonToken.NULL) {
       `in`.nextNull()
@@ -69,9 +69,9 @@ class ConcurrentHashMapTypeAdapter : TypeAdapter<ConcurrentHashMap<String?, Any?
         writeObject(out, iterator.next())
       }
       out.endArray()
-    } else if (value is ConcurrentHashMap<*, *>) {
+    } else if (value is Map<*, *>) {
       out.beginObject()
-      val iterator: Iterator<Map.Entry<String?, Any?>> = (value as ConcurrentHashMap<String?, Any?>)
+      val iterator: Iterator<Map.Entry<String?, Any?>> = (value as Map<String?, Any?>)
           .entries
           .iterator()
       while (iterator.hasNext()) {

--- a/src/main/kotlin/io/kuzzle/sdk/coreClasses/json/JsonSerializer.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/coreClasses/json/JsonSerializer.kt
@@ -2,16 +2,16 @@ package io.kuzzle.sdk.coreClasses.json
 
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
-import java.util.concurrent.ConcurrentHashMap
+
 
 object JsonSerializer {
   private var gson: Gson? = null
-  fun deserialize(rawJson: String?): ConcurrentHashMap<*, *> {
-    return gson!!.fromJson(rawJson, ConcurrentHashMap::class.java)
+  fun deserialize(rawJson: String?): Map<*, *> {
+    return gson!!.fromJson(rawJson, Map::class.java)
   }
 
-  fun serialize(map: ConcurrentHashMap<String?, Any?>?): String {
-    return gson!!.toJson(map, ConcurrentHashMap::class.java)
+  fun serialize(map: Map<String?, Any?>?): String {
+    return gson!!.toJson(map, Map::class.java)
   }
 
   init {
@@ -19,8 +19,8 @@ object JsonSerializer {
         .disableHtmlEscaping()
         .disableInnerClassSerialization()
         .serializeNulls()
-        .registerTypeAdapter(ConcurrentHashMap::class.java,
-            ConcurrentHashMapTypeAdapter())
+        .registerTypeAdapter(Map::class.java,
+            MapTypeAdapter())
         .create()
   }
 }

--- a/src/main/kotlin/io/kuzzle/sdk/coreClasses/maps/KuzzleMap.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/coreClasses/maps/KuzzleMap.kt
@@ -1,27 +1,24 @@
 package io.kuzzle.sdk.coreClasses.maps
 
-import java.util.*
-import java.util.concurrent.ConcurrentHashMap
-
 /**
- * CustomMap is a Class that extends ConcurrentHashMap to be ThreadSafe and that
- * has the purpose of giving a wrapper on top of ConcurrentHashMap to easily
+ * KuzzleMap is a Class that extends Map to be ThreadSafe and that
+ * has the purpose of giving a wrapper on top of Map to easily
  * manipulate them.
  */
-class KuzzleMap : ConcurrentHashMap<String?, Any?> {
+class KuzzleMap : HashMap<String?, Any?> {
   /**
    * Create a new instance of CustomMap
    */
   constructor() : super() {}
 
   /**
-   * Create a new instance of CustomMap from a ConcurrentHashMap<String></String>,
+   * Create a new instance of CustomMap from a Map<String></String>,
    * Object>.
    *
    * @param map
-   * ConcurrentHashMap<String></String>, Object> representing JSON.
+   * Map<String></String>, Object> representing JSON.
    */
-  constructor(map: ConcurrentHashMap<String?, Any?>) : super() {
+  constructor(map: Map<String?, Any?>) : super() {
     val it = map.entries.iterator()
     while (it.hasNext()) {
       val entry = it.next()
@@ -99,14 +96,14 @@ class KuzzleMap : ConcurrentHashMap<String?, Any?> {
   }
 
   /**
-   * Check whether the key value is a ConcurrentHashMap or not.
+   * Check whether the key value is a Map or not.
    *
    * @param key
    * a String representing the key.
-   * @return true if the key is a ConcurrentHashMap.
+   * @return true if the key is a Map.
    */
   fun isMap(key: String): Boolean {
-    return super.get(key) is ConcurrentHashMap<*, *>
+    return super.get(key) is Map<*, *>
   }
 
   /**
@@ -155,14 +152,14 @@ class KuzzleMap : ConcurrentHashMap<String?, Any?> {
 
   /**
    * Return the specified key value or null if the value is not a
-   * ConcurrentHashMap.
+   * Map.
    *
    * @param key
    * a String representing the key.
-   * @return The ConcurrentHashMap at the key or null
+   * @return The Map at the key or null
    */
   fun getMap(key: String): KuzzleMap? {
-    return if (isMap(key)) from(super.get(key) as ConcurrentHashMap<String?, Any?>) else null
+    return if (isMap(key)) from(super.get(key) as Map<String?, Any?>) else null
   }
 
   /**
@@ -215,14 +212,14 @@ class KuzzleMap : ConcurrentHashMap<String?, Any?> {
 
   /**
    * Return the specified key value or the def value if the value is nul or not
-   * a ConcurrentHashMap.
+   * a Map.
    *
    * @param key
    * a String representing the key.
-   * @return The ConcurrentHashMap at the key or def value
+   * @return The Map at the key or def value
    */
-  fun optMap(key: String, def: ConcurrentHashMap<String?, Any?>): KuzzleMap {
-    return if (isMap(key)) from(super.get(key) as ConcurrentHashMap<String?, Any?>) else from(def)
+  fun optMap(key: String, def: Map<String?, Any?>): KuzzleMap {
+    return if (isMap(key)) from(super.get(key) as Map<String?, Any?>) else from(def)
   }
 
   companion object {
@@ -232,16 +229,14 @@ class KuzzleMap : ConcurrentHashMap<String?, Any?> {
     private const val serialVersionUID = -3027862451021177820L
 
     /**
-     * Convert à ConcurrentHashMap<String></String>, Object> to a CustomMap
+     * Convert à Map<String></String>, Object> to a CustomMap
      *
      * @param map
-     * ConcurrentHashMap<String></String>, Object> representing JSON.
+     * Map<String></String>, Object> representing JSON.
      * @return a CustomMap instance
      */
-    fun from(map: ConcurrentHashMap<String?, Any?>): KuzzleMap {
-      return if (map is KuzzleMap) {
-        map
-      } else KuzzleMap(map)
+    fun from(map: Map<String?, Any?>): KuzzleMap {
+      return KuzzleMap(map)
     }
   }
 }

--- a/src/main/kotlin/io/kuzzle/sdk/coreClasses/maps/Serializable.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/coreClasses/maps/Serializable.kt
@@ -1,11 +1,11 @@
 package io.kuzzle.sdk.coreClasses.maps
 
-import java.util.concurrent.ConcurrentHashMap
+
 
 interface Serializable {
   @Throws(Exception::class)
-  fun fromMap(map: ConcurrentHashMap<String?, Any?>?)
+  fun fromMap(map: Map<String?, Any?>?)
 
   @Throws(Exception::class)
-  fun toMap(): ConcurrentHashMap<String?, Any?>?
+  fun toMap(): Map<String?, Any?>?
 }

--- a/src/main/kotlin/io/kuzzle/sdk/coreClasses/responses/ErrorResponse.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/coreClasses/responses/ErrorResponse.kt
@@ -2,7 +2,7 @@ package io.kuzzle.sdk.coreClasses.responses
 
 import io.kuzzle.sdk.coreClasses.maps.KuzzleMap
 import io.kuzzle.sdk.coreClasses.maps.Serializable
-import java.util.concurrent.ConcurrentHashMap
+
 
 class ErrorResponse : Serializable {
   /**
@@ -25,7 +25,7 @@ class ErrorResponse : Serializable {
    */
   var stack: String? = null
 
-  override fun fromMap(map: ConcurrentHashMap<String?, Any?>?) {
+  override fun fromMap(map: Map<String?, Any?>?) {
     if (map == null) return
     val kuzzleMap: KuzzleMap? = KuzzleMap?.from(map)
     status = kuzzleMap?.optNumber("status", 0)!!.toInt()
@@ -34,8 +34,8 @@ class ErrorResponse : Serializable {
     id = kuzzleMap?.getString("id")
   }
 
-  override fun toMap(): ConcurrentHashMap<String?, Any?> {
-    val map: ConcurrentHashMap<String?, Any?> = KuzzleMap()
+  override fun toMap(): Map<String?, Any?> {
+    val map = KuzzleMap()
     map["status"] = status
     map["message"] = message!!
     map["stack"] = stack!!

--- a/src/main/kotlin/io/kuzzle/sdk/coreClasses/responses/Response.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/coreClasses/responses/Response.kt
@@ -3,10 +3,10 @@ package io.kuzzle.sdk.coreClasses.responses
 import io.kuzzle.sdk.coreClasses.exceptions.KuzzleExceptionCode
 import io.kuzzle.sdk.coreClasses.maps.KuzzleMap
 import io.kuzzle.sdk.coreClasses.maps.Serializable
-import java.util.concurrent.ConcurrentHashMap
+
 
 class Response : Serializable {
-  var mapResponse: ConcurrentHashMap<String?, Any?>? = null
+  var mapResponse: Map<String?, Any?>? = null
     private set
 
   var room: String? = null
@@ -54,7 +54,7 @@ class Response : Serializable {
   /**
    * Volatile data.
    */
-  var Volatile: ConcurrentHashMap<String?, Any?>? = null
+  var Volatile: Map<String?, Any?>? = null
   // The following properties are specific to real-time notifications
   /**
    * Network protocol at the origin of the real-time notification.
@@ -81,7 +81,7 @@ class Response : Serializable {
    */
   var type: String? = null
 
-  override fun fromMap(map: ConcurrentHashMap<String?, Any?>?) {
+  override fun fromMap(map: Map<String?, Any?>?) {
     if (map == null) return
 
     mapResponse = map
@@ -103,7 +103,7 @@ class Response : Serializable {
     action = kuzzleMap.getString("action")
     index = kuzzleMap.getString("index")
     collection = kuzzleMap.getString("collection")
-    Volatile = kuzzleMap.optMap("volatile", ConcurrentHashMap<String?, Any?>())
+    Volatile = kuzzleMap.optMap("volatile", HashMap())
     protocol = kuzzleMap.getString("protocol")
     scope = kuzzleMap.getString("scope")
     state = kuzzleMap.getString("state")
@@ -114,8 +114,8 @@ class Response : Serializable {
     type = kuzzleMap.getString("type")
   }
 
-  override fun toMap(): ConcurrentHashMap<String?, Any?> {
-    val map = ConcurrentHashMap<String?, Any?>()
+  override fun toMap(): Map<String?, Any?> {
+    val map = HashMap<String?, Any?>()
 
     room?.let { map.put("room", it) }
     result?.let { map.put("result", it) }

--- a/src/main/kotlin/io/kuzzle/sdk/protocol/AbstractProtocol.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/protocol/AbstractProtocol.kt
@@ -1,11 +1,11 @@
 package io.kuzzle.sdk.protocol
 
 import io.kuzzle.sdk.events.EventManager
-import java.util.concurrent.ConcurrentHashMap
+
 
 abstract class AbstractProtocol: EventManager() {
   abstract var state: ProtocolState
   abstract fun connect()
   abstract fun disconnect()
-  abstract fun send(payload: ConcurrentHashMap<String?, Any?>)
+  abstract fun send(payload: Map<String?, Any?>)
 }

--- a/src/main/kotlin/io/kuzzle/sdk/protocol/WebSocket.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/protocol/WebSocket.kt
@@ -20,7 +20,7 @@ import java.io.IOException
 import java.net.ConnectException
 import java.net.SocketException
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ConcurrentHashMap
+
 import java.util.concurrent.ConcurrentLinkedQueue
 import kotlin.concurrent.thread
 
@@ -153,7 +153,7 @@ open class WebSocket : AbstractProtocol {
     }
   }
 
-  override fun send(payload: ConcurrentHashMap<String?, Any?>) {
+  override fun send(payload: Map<String?, Any?>) {
     queue.add(JsonSerializer.serialize(payload))
   }
 }

--- a/src/test/kotlin/io/kuzzle/sdk/protocolTest/WebSocketTests.kt
+++ b/src/test/kotlin/io/kuzzle/sdk/protocolTest/WebSocketTests.kt
@@ -69,7 +69,7 @@ class WebSocketTests {
   @KtorExperimentalAPI
   @Test
   fun sendTest() {
-    val query = Map<String?, Any?>().apply {
+    val query = HashMap<String?, Any?>().apply {
       put("controller", "server")
       put("action", "now")
     }

--- a/src/test/kotlin/io/kuzzle/sdk/protocolTest/WebSocketTests.kt
+++ b/src/test/kotlin/io/kuzzle/sdk/protocolTest/WebSocketTests.kt
@@ -14,7 +14,7 @@ import io.kuzzle.sdk.protocol.WebSocket
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
-import java.util.concurrent.ConcurrentHashMap
+
 
 class WebSocketTests {
   inner class MockedSocket(host: String) : WebSocket(host) {
@@ -69,7 +69,7 @@ class WebSocketTests {
   @KtorExperimentalAPI
   @Test
   fun sendTest() {
-    val query = ConcurrentHashMap<String?, Any?>().apply {
+    val query = Map<String?, Any?>().apply {
       put("controller", "server")
       put("action", "now")
     }


### PR DESCRIPTION
## What does this PR do ?

Use the `Map` interface instead of `ConcurrentHashMap` to let the developer choose what kind of Map to use.