### PR TITLE
Fix freeze on reconnection attempts

### DIFF
--- a/src/main/kotlin/io/kuzzle/sdk/protocol/WebSocket.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/protocol/WebSocket.kt
@@ -66,10 +66,11 @@ open class WebSocket : AbstractProtocol {
         if (!autoReconnect)
             return CompletableFuture.completedFuture(false);
 
+        state = ProtocolState.RECONNECTING
+        trigger("networkStateChange", state.toString())
+        
         return CompletableFuture.supplyAsync(
             fun(): Boolean {
-                state = ProtocolState.RECONNECTING
-                trigger("networkStateChange", state.toString())
         
                 while (retryCount < reconnectionRetries) {
                     retryCount++

--- a/src/main/kotlin/io/kuzzle/sdk/protocol/WebSocket.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/protocol/WebSocket.kt
@@ -196,12 +196,14 @@ open class WebSocket : AbstractProtocol {
     }
 
     override fun disconnect() {
-        state = ProtocolState.CLOSE
-        trigger("networkStateChange", ProtocolState.CLOSE.toString())
-        stopRetryingToConnect.set(true)
-        GlobalScope.launch {
-            ws?.close()
-            ws = null
+        if (state != ProtocolState.CLOSE) {
+            state = ProtocolState.CLOSE
+            trigger("networkStateChange", ProtocolState.CLOSE.toString())
+            stopRetryingToConnect.set(true)
+            GlobalScope.launch {
+                ws?.close()
+                ws = null
+            }
         }
     }
 

--- a/src/main/kotlin/io/kuzzle/sdk/protocol/WebSocket.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/protocol/WebSocket.kt
@@ -169,20 +169,16 @@ open class WebSocket : AbstractProtocol {
                     is SocketException,
                     is IOException -> {
                         if (state != ProtocolState.RECONNECTING) {
-                            // Fast fail, avoid spawning Future
-                            if (!autoReconnect || stopRetryingToConnect.get()) {
-                                wait.completeExceptionally(e)
-                            } else {
-                                tryToReconnect().thenAcceptAsync(
-                                    fun (success: Boolean) {
-                                        if (success) {
-                                            wait.complete(null)
-                                        } else {
-                                            wait.completeExceptionally(e)
-                                        }
+                            tryToReconnect().thenAcceptAsync(
+                                fun (success: Boolean) {
+                                    if (success) {
+                                        wait.complete(null)
+                                    } else {
+                                        wait.completeExceptionally(e)
                                     }
-                                )
-                            }
+                                    stopRetryingToConnect.set(false)
+                                }
+                            )
                         } else {
                             wait.completeExceptionally(e)
                         }

--- a/src/main/kotlin/io/kuzzle/sdk/protocol/WebSocket.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/protocol/WebSocket.kt
@@ -94,7 +94,7 @@ open class WebSocket : AbstractProtocol {
     @KtorExperimentalAPI
     override fun connect() {
         if (this.stopRetryingToConnect.get())
-            throw Exception("Reconnection Aborted")
+            throw Exception("Connection Aborted")
 
         val wait = CompletableFuture<Void>()
         val block: suspend DefaultClientWebSocketSession.() -> Unit = {

--- a/src/main/kotlin/io/kuzzle/sdk/protocol/WebSocket.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/protocol/WebSocket.kt
@@ -21,7 +21,6 @@ import java.net.ConnectException
 import java.net.SocketException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentLinkedQueue
-import java.util.function.Supplier
 import kotlin.concurrent.thread
 
 open class WebSocket : AbstractProtocol {
@@ -64,14 +63,12 @@ open class WebSocket : AbstractProtocol {
 
     private fun tryToReconnect(): CompletableFuture<Boolean> {
         if (!autoReconnect)
-            return CompletableFuture.completedFuture(false);
+            return CompletableFuture.completedFuture(false)
 
         state = ProtocolState.RECONNECTING
         trigger("networkStateChange", state.toString())
-        
         return CompletableFuture.supplyAsync(
             fun(): Boolean {
-        
                 while (retryCount < reconnectionRetries) {
                     retryCount++
                     Thread.sleep(reconnectionDelay)
@@ -169,7 +166,7 @@ open class WebSocket : AbstractProtocol {
                                         wait.complete(null)
                                     } else {
                                         wait.completeExceptionally(e)
-                                    }                        
+                                    }
                                 }
                             )
                         } else {

--- a/src/main/kotlin/io/kuzzle/sdk/protocol/WebSocket.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/protocol/WebSocket.kt
@@ -94,8 +94,8 @@ open class WebSocket : AbstractProtocol {
     @KtorExperimentalAPI
     override fun connect() {
         if (this.stopRetryingToConnect.get())
-            return
-            
+            throw Exception("Reconnection Aborted")
+
         val wait = CompletableFuture<Void>()
         val block: suspend DefaultClientWebSocketSession.() -> Unit = {
             ws = this


### PR DESCRIPTION
<!--
  This template is optional.
  It simply serves to provide a guide to allow a better review of pull requests.
-->

<!--
  IMPORTANT
  Don't forget to add the corresponding "changelog:xxx" label to your PR.
  This is part of our release process in order to generate the change log.
-->


## What does this PR do ?
<!-- Please fill this section -->
This PR aims to fix a bug that occurs when trying to reconnect and that freezes the SDK during the reconnection

- `tryToReconnect` now returns a `CompletableFuture<Boolean>` instead of a `Boolean`
- The connect method now chains CompletableFutures to resolve the connection / reconnection

## Other
- Add infinite reconnection attempts by setting it to -1
- Disconnect now cancel the reconnection attempts
