### PR TITLE
Fix collection:create not sending the values correctly

### DIFF
--- a/src/main/kotlin/io/kuzzle/sdk/controllers/CollectionController.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/controllers/CollectionController.kt
@@ -20,7 +20,7 @@ class CollectionController(kuzzle: Kuzzle) : BaseController(kuzzle) {
                     put("action", "create")
                     put("index", index)
                     put("collection", collection)
-                    put("definition", definition)
+                    put("body", definition)
                 }
             )
             .thenApplyAsync { null }


### PR DESCRIPTION
## What does this PR do ?
This PR fixes the collection:create method that was not working properly because of the settings and mappings being sent in the `definition` instead of the `body`.


