### PR TITLE
Fix a special case where only requestId is sent back instead of room

### DIFF
--- a/src/main/kotlin/io/kuzzle/sdk/Kuzzle.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/Kuzzle.kt
@@ -56,8 +56,10 @@ class Kuzzle {
         val response = Response().apply {
             fromMap(JsonSerializer.deserialize(message) as Map<String?, Any?>)
         }
+        
+        val requestId = response.room ?: response.requestId
 
-        if (queries.size == 0 || (queries.size != 0 && (response.room == null || queries[response.room!!] == null))) {
+        if (queries.size == 0 || (queries.size != 0 && (requestId == null || queries[requestId] == null))) {
             protocol.trigger("unhandledResponse", message)
             return
         }

--- a/src/main/kotlin/io/kuzzle/sdk/Kuzzle.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/Kuzzle.kt
@@ -56,7 +56,7 @@ class Kuzzle {
         val response = Response().apply {
             fromMap(JsonSerializer.deserialize(message) as Map<String?, Any?>)
         }
-        
+
         val requestId = response.room ?: response.requestId
 
         if (queries.size == 0 || (queries.size != 0 && (requestId == null || queries[requestId] == null))) {


### PR DESCRIPTION
## What does this PR do ?

Fix a special case where only the requestId is sent back by Kuzzle instead of the room property.
This only happens when we successfuly parse the Json message but the failed to convert it to a Request