### PR TITLE
Open Kuzzle class so it can be extended

### DIFF
--- a/src/main/kotlin/io/kuzzle/sdk/Kuzzle.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/Kuzzle.kt
@@ -19,7 +19,7 @@ import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import kotlin.collections.HashMap
 
-class Kuzzle {
+open class Kuzzle {
     val protocol: AbstractProtocol
     val autoResubscribe: Boolean
     private val queries: HashMap<String, CompletableFuture<Response>> = HashMap()


### PR DESCRIPTION
## What does this PR do ?

In the Java SDK the Kuzzle class wasn't final and could be extended which is not the case in the SDK-JVM, it seems that the `open` keyword has been forgotten and since we have no interest in preventing user from extending the Kuzzle class I changed this behaviour to enable extending the Kuzzle class.