### PR TITLE
Fix HTTP Protocol and overall SDK enhancements

### DIFF
--- a/.ci/doc/config.yml
+++ b/.ci/doc/config.yml
@@ -1,8 +1,11 @@
 ---
 snippets:
   mount: /mnt
-  path: 'doc/**/snippets/*-java.test.yml'
+  path: 'doc/**/snippets/*.test.yml'
   templates: /mnt/.ci/doc/templates
+  protocols:
+    - http
+    - websocket
 
 runners:
   default: java

--- a/.ci/doc/docker-compose.yml
+++ b/.ci/doc/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - CONFIG_FILE=/mnt/.ci/doc/config.yml
 
   doc-runner-java:
-    image: adoptopenjdk/openjdk11
+    image: adoptopenjdk/openjdk8
     command: >
       sh -c '
         mkdir -p /var/snippets/java;

--- a/.ci/doc/templates/catch.tpl.java
+++ b/.ci/doc/templates/catch.tpl.java
@@ -10,7 +10,7 @@ public class SnippetTest {
   public static void main(String[] argv) {
     try {
       AbstractProtocol protocol;
-      if (System.getenv("SNIPPET_PROTOCOL") == "http") {
+      if (System.getenv("SNIPPET_PROTOCOL") != null && System.getenv("SNIPPET_PROTOCOL").equals("http")) {
         protocol = new Http("kuzzle");
       } else {
         protocol = new WebSocket("kuzzle");

--- a/.ci/doc/templates/catch.tpl.kt
+++ b/.ci/doc/templates/catch.tpl.kt
@@ -6,7 +6,7 @@ import io.kuzzle.sdk.coreClasses.responses.Response
 
 fun main() {
   val protocol: AbstractProtocol;
-  if (System.getenv("SNIPPET_PROTOCOL") == "http") {
+  if (System.getenv("SNIPPET_PROTOCOL") != null && System.getenv("SNIPPET_PROTOCOL") == "http") {
     protocol = Http("kuzzle")
   } else {
     protocol = WebSocket("kuzzle")

--- a/.ci/doc/templates/default.tpl.java
+++ b/.ci/doc/templates/default.tpl.java
@@ -11,7 +11,7 @@ public class SnippetTest {
   public static void main(String[] argv) {
     try {
       AbstractProtocol protocol;
-      if (System.getenv("SNIPPET_PROTOCOL") == "http") {
+      if (System.getenv("SNIPPET_PROTOCOL") != null && System.getenv("SNIPPET_PROTOCOL").equals("http")) {
         protocol = new Http("kuzzle");
       } else {
         protocol = new WebSocket("kuzzle");

--- a/.ci/doc/templates/default.tpl.kt
+++ b/.ci/doc/templates/default.tpl.kt
@@ -9,7 +9,7 @@ import java.util.*;
 
 fun main() {
   val protocol: AbstractProtocol;
-  if (System.getenv("SNIPPET_PROTOCOL") == "http") {
+  if (System.getenv("SNIPPET_PROTOCOL") != null && System.getenv("SNIPPET_PROTOCOL") == "http") {
     protocol = Http("kuzzle")
   } else {
     protocol = WebSocket("kuzzle")

--- a/.ci/doc/templates/print-result-array.tpl.java
+++ b/.ci/doc/templates/print-result-array.tpl.java
@@ -10,7 +10,7 @@ public class SnippetTest {
   public static void main(String[] argv) {
     try {
       AbstractProtocol protocol;
-      if (System.getenv("SNIPPET_PROTOCOL") == "http") {
+      if (System.getenv("SNIPPET_PROTOCOL") != null && System.getenv("SNIPPET_PROTOCOL").equals("http")) {
         protocol = new Http("kuzzle");
       } else {
         protocol = new WebSocket("kuzzle");

--- a/.ci/doc/templates/print-result-array.tpl.kt
+++ b/.ci/doc/templates/print-result-array.tpl.kt
@@ -8,7 +8,7 @@ import io.kuzzle.sdk.coreClasses.lang.Lang
 
 fun main() {
   val protocol: AbstractProtocol;
-  if (System.getenv("SNIPPET_PROTOCOL") == "http") {
+  if (System.getenv("SNIPPET_PROTOCOL") != null && System.getenv("SNIPPET_PROTOCOL") == "http") {
     protocol = Http("kuzzle")
   } else {
     protocol = WebSocket("kuzzle")

--- a/.ci/doc/templates/print-result-arraylist.tpl.java
+++ b/.ci/doc/templates/print-result-arraylist.tpl.java
@@ -10,7 +10,7 @@ public class SnippetTest {
   public static void main(String[] argv) {
     try {
       AbstractProtocol protocol;
-      if (System.getenv("SNIPPET_PROTOCOL") == "http") {
+      if (System.getenv("SNIPPET_PROTOCOL") != null && System.getenv("SNIPPET_PROTOCOL").equals("http")) {
         protocol = new Http("kuzzle");
       } else {
         protocol = new WebSocket("kuzzle");

--- a/.ci/doc/templates/print-result-arraylist.tpl.kt
+++ b/.ci/doc/templates/print-result-arraylist.tpl.kt
@@ -7,7 +7,7 @@ import io.kuzzle.sdk.coreClasses.lang.Lang
 
 fun main() {
   val protocol: AbstractProtocol;
-  if (System.getenv("SNIPPET_PROTOCOL") == "http") {
+  if (System.getenv("SNIPPET_PROTOCOL") != null && System.getenv("SNIPPET_PROTOCOL") == "http") {
     protocol = Http("kuzzle")
   } else {
     protocol = WebSocket("kuzzle")

--- a/.ci/doc/templates/print-result.tpl.java
+++ b/.ci/doc/templates/print-result.tpl.java
@@ -10,7 +10,7 @@ public class SnippetTest {
   public static void main(String[] argv) {
     try {
       AbstractProtocol protocol;
-      if (System.getenv("SNIPPET_PROTOCOL") == "http") {
+      if (System.getenv("SNIPPET_PROTOCOL") != null && System.getenv("SNIPPET_PROTOCOL").equals("http")) {
         protocol = new Http("kuzzle");
       } else {
         protocol = new WebSocket("kuzzle");

--- a/.ci/doc/templates/print-search-result.tpl.java
+++ b/.ci/doc/templates/print-search-result.tpl.java
@@ -11,7 +11,7 @@ public class SnippetTest {
   public static void main(String[] argv) {
     try {
       AbstractProtocol protocol;
-      if (System.getenv("SNIPPET_PROTOCOL") == "http") {
+      if (System.getenv("SNIPPET_PROTOCOL") != null && System.getenv("SNIPPET_PROTOCOL").equals("http")) {
         protocol = new Http("kuzzle");
       } else {
         protocol = new WebSocket("kuzzle");
@@ -19,7 +19,7 @@ public class SnippetTest {
       Kuzzle kuzzle = new Kuzzle(protocol);
       kuzzle.connect();
       [snippet-code]
-          System.out.println("Successfully retrieved " + matched.size() + " documents");
+      System.out.println("Successfully retrieved " + matched.size() + " documents");
     } catch (Exception e) {
       e.printStackTrace();
     } finally {

--- a/.ci/doc/templates/print-search-result.tpl.kt
+++ b/.ci/doc/templates/print-search-result.tpl.kt
@@ -8,7 +8,7 @@ import io.kuzzle.sdk.coreClasses.lang.Lang
 
 fun main() {
   val protocol: AbstractProtocol;
-  if (System.getenv("SNIPPET_PROTOCOL") == "http") {
+  if (System.getenv("SNIPPET_PROTOCOL") != null && System.getenv("SNIPPET_PROTOCOL") == "http") {
     protocol = Http("kuzzle")
   } else {
     protocol = WebSocket("kuzzle")

--- a/.ci/doc/templates/without-connect.tpl.java
+++ b/.ci/doc/templates/without-connect.tpl.java
@@ -8,7 +8,7 @@ public class SnippetTest {
   public static void main(String[] argv) {
     try {
       AbstractProtocol protocol;
-      if (System.getenv("SNIPPET_PROTOCOL") == "http") {
+      if (System.getenv("SNIPPET_PROTOCOL") != null && System.getenv("SNIPPET_PROTOCOL").equals("http")) {
         protocol = new Http("kuzzle");
       } else {
         protocol = new WebSocket("kuzzle");

--- a/.ci/doc/templates/without-connect.tpl.kt
+++ b/.ci/doc/templates/without-connect.tpl.kt
@@ -5,7 +5,7 @@ import java.util.concurrent.ExecutionException
 
 fun main() {
   val protocol: AbstractProtocol;
-  if (System.getenv("SNIPPET_PROTOCOL") == "http") {
+  if (System.getenv("SNIPPET_PROTOCOL") != null && System.getenv("SNIPPET_PROTOCOL") == "http") {
     protocol = Http("kuzzle")
   } else {
     protocol = WebSocket("kuzzle")

--- a/README.md
+++ b/README.md
@@ -33,12 +33,6 @@ You can then find the jars file in build/libs/
 
 ## Installation
 
-### Bintray repository
-
-The SDK is available for both x86 and amd64 architectures on bintray:
-
-https://bintray.com/kuzzle/maven
-
 ### Maven
 
 ```xml
@@ -91,12 +85,12 @@ configurations {
 If you are using the thin jar, make sure to add the following dependencies:
 
 ```groovy
-    implementation("io.ktor:ktor-client-core:1.5.2")
-    implementation("io.ktor:ktor-client-websockets:1.5.2")
-    implementation("io.ktor:ktor-client-okhttp:1.5.2")
-    implementation("io.ktor:ktor-client-cio:1.5.2")
-    implementation("io.ktor:ktor-client-json:1.5.2")
-    implementation("io.ktor:ktor-client-gson:1.5.2")
-    implementation("io.ktor:ktor-client-serialization:1.5.2")
+    implementation("io.ktor:ktor-client-core:1.6.8")
+    implementation("io.ktor:ktor-client-websockets:1.6.8")
+    implementation("io.ktor:ktor-client-okhttp:1.6.8")
+    implementation("io.ktor:ktor-client-cio:1.6.8")
+    implementation("io.ktor:ktor-client-json:1.6.8")
+    implementation("io.ktor:ktor-client-gson:1.6.8")
+    implementation("io.ktor:ktor-client-serialization:1.6.8")
     implementation("com.google.code.gson:gson:2.9.0")
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The complete SDK documentation is available [here](https://docs.kuzzle.io/sdk/jv
 
 ## Protocol used
 
-The JVM SDK implements the websocket protocol.
+The JVM SDK implements the websocket protocol and http protocol.
 
 ### Build jar
 
@@ -91,11 +91,12 @@ configurations {
 If you are using the thin jar, make sure to add the following dependencies:
 
 ```groovy
+    implementation("io.ktor:ktor-client-core:1.5.2")
     implementation("io.ktor:ktor-client-websockets:1.5.2")
     implementation("io.ktor:ktor-client-okhttp:1.5.2")
     implementation("io.ktor:ktor-client-cio:1.5.2")
     implementation("io.ktor:ktor-client-json:1.5.2")
     implementation("io.ktor:ktor-client-gson:1.5.2")
     implementation("io.ktor:ktor-client-serialization:1.5.2")
-    implementation("com.google.code.gson:gson:2.8.5")
+    implementation("com.google.code.gson:gson:2.9.0")
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
     `maven-publish`
     signing
     jacoco
-    kotlin("jvm") version "1.3.61"
+    kotlin("jvm") version "1.6.10"
 }
 
 val artifactName = "sdk-jvm"
@@ -36,7 +36,7 @@ val pomDeveloperName = "kuzzle"
 
 group = "io.kuzzle.sdk"
 version = "1.2.3"
-val ktorVersion = "1.5.2"
+val ktorVersion = "1.6.8"
 
 repositories {
     mavenCentral()

--- a/doc/1/controllers/auth/check-rights/snippets/check-rights-java.test.yml
+++ b/doc/1/controllers/auth/check-rights/snippets/check-rights-java.test.yml
@@ -5,6 +5,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/users/foo?refresh=wait_for
 template: print-result
 expected: true
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/check-rights/snippets/check-rights-kotlin.test.yml
+++ b/doc/1/controllers/auth/check-rights/snippets/check-rights-kotlin.test.yml
@@ -5,6 +5,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/users/foo?refresh=wait_for
 template: print-result
 expected: true
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/check-token/snippets/check-token-java.test.yml
+++ b/doc/1/controllers/auth/check-token/snippets/check-token-java.test.yml
@@ -5,6 +5,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/users/foo?refresh=wait_for
 template: default
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/check-token/snippets/check-token-kotlin.test.yml
+++ b/doc/1/controllers/auth/check-token/snippets/check-token-kotlin.test.yml
@@ -5,6 +5,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/users/foo?refresh=wait_for
 template: default
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/create-my-credentials/snippets/create-my-credentials-java.test.yml
+++ b/doc/1/controllers/auth/create-my-credentials/snippets/create-my-credentials-java.test.yml
@@ -5,6 +5,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/users/foo?refresh=wait_for
 template: catch
 expected:  io.kuzzle.sdk.coreClasses.exceptions.ApiErrorException:\ Unknown\ authentication\ strategy\ "other"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/create-my-credentials/snippets/create-my-credentials-kotlin.test.yml
+++ b/doc/1/controllers/auth/create-my-credentials/snippets/create-my-credentials-kotlin.test.yml
@@ -5,6 +5,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/users/foo?refresh=wait_for
 template: catch
 expected:  io.kuzzle.sdk.coreClasses.exceptions.ApiErrorException:\ Unknown\ authentication\ strategy\ "other"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/credentials-exist/snippets/credentials-exist-java.test.yml
+++ b/doc/1/controllers/auth/credentials-exist/snippets/credentials-exist-java.test.yml
@@ -5,6 +5,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/users/foo?refresh=wait_for
 template: print-result
 expected: "true"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/credentials-exist/snippets/credentials-exist-kotlin.test.yml
+++ b/doc/1/controllers/auth/credentials-exist/snippets/credentials-exist-kotlin.test.yml
@@ -5,6 +5,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/users/foo?refresh=wait_for
 template: print-result
 expected: "true"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/delete-my-credentials/snippets/delete-my-credentials-java.test.yml
+++ b/doc/1/controllers/auth/delete-my-credentials/snippets/delete-my-credentials-java.test.yml
@@ -5,6 +5,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/users/foo?refresh=wait_for
 template: default
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/delete-my-credentials/snippets/delete-my-credentials-kotlin.test.yml
+++ b/doc/1/controllers/auth/delete-my-credentials/snippets/delete-my-credentials-kotlin.test.yml
@@ -5,6 +5,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/users/foo?refresh=wait_for
 template: default
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/get-current-user/snippets/get-current-user-java.test.yml
+++ b/doc/1/controllers/auth/get-current-user/snippets/get-current-user-java.test.yml
@@ -5,7 +5,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/users/foo?refresh=wait_for
 template: print-result
 expected: ^{strategies=\[local\],\ _source={profileIds=\[default\],\ _kuzzle_info={.*}},\ _id=foo}$
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/get-current-user/snippets/get-current-user-kotlin.test.yml
+++ b/doc/1/controllers/auth/get-current-user/snippets/get-current-user-kotlin.test.yml
@@ -5,7 +5,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/users/foo?refresh=wait_for
 template: print-result
 expected: ^{strategies=\[local\],\ _source={profileIds=\[default\],\ _kuzzle_info={.*}},\ _id=foo}$
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/get-my-credentials/snippets/get-my-credentials-java.test.yml
+++ b/doc/1/controllers/auth/get-my-credentials/snippets/get-my-credentials-java.test.yml
@@ -6,7 +6,3 @@ hooks:
 template: print-result
 expected:
   - {kuid=foo,\ username=foo}
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/get-my-credentials/snippets/get-my-credentials-kotlin.test.yml
+++ b/doc/1/controllers/auth/get-my-credentials/snippets/get-my-credentials-kotlin.test.yml
@@ -6,7 +6,3 @@ hooks:
 template: print-result
 expected:
   - {kuid=foo,\ username=foo}
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/get-my-rights/snippets/get-my-rights-java.test.yml
+++ b/doc/1/controllers/auth/get-my-rights/snippets/get-my-rights-java.test.yml
@@ -5,7 +5,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/users/foo?refresh=wait_for
 template: print-result
 expected: [{controller=*,\ action=*,\ index=*,\ collection=*,\ value=allowed}]
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/get-my-rights/snippets/get-my-rights-kotlin.test.yml
+++ b/doc/1/controllers/auth/get-my-rights/snippets/get-my-rights-kotlin.test.yml
@@ -5,7 +5,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/users/foo?refresh=wait_for
 template: print-result
 expected: [{controller=*,\ action=*,\ index=*,\ collection=*,\ value=allowed}]
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/get-strategies/snippets/get-strategies-java.test.yml
+++ b/doc/1/controllers/auth/get-strategies/snippets/get-strategies-java.test.yml
@@ -5,7 +5,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/users/foo?refresh=wait_for
 template: print-result
 expected: [local]
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/get-strategies/snippets/get-strategies-kotlin.test.yml
+++ b/doc/1/controllers/auth/get-strategies/snippets/get-strategies-kotlin.test.yml
@@ -5,7 +5,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/users/foo?refresh=wait_for
 template: print-result
 expected: [local]
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/login/snippets/login-java.test.yml
+++ b/doc/1/controllers/auth/login/snippets/login-java.test.yml
@@ -6,7 +6,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/users/foo?refresh=wait_for
 template: print-result
 expected: ^{jwt=.*,\ _id=foo,\ ttl=3600000,\ expiresAt=[0-9]+}$
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/login/snippets/login-kotlin.test.yml
+++ b/doc/1/controllers/auth/login/snippets/login-kotlin.test.yml
@@ -6,7 +6,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/users/foo?refresh=wait_for
 template: print-result
 expected: ^{jwt=.*,\ _id=foo,\ ttl=3600000,\ expiresAt=[0-9]+}$
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/logout/snippets/logout-java.test.yml
+++ b/doc/1/controllers/auth/logout/snippets/logout-java.test.yml
@@ -5,7 +5,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/users/foo?refresh=wait_for
 template: default
 expected: Success
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/logout/snippets/logout-kotlin.test.yml
+++ b/doc/1/controllers/auth/logout/snippets/logout-kotlin.test.yml
@@ -5,7 +5,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/users/foo?refresh=wait_for
 template: default
 expected: Success
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/refresh-token/snippets/refresh-token-java.test.yml
+++ b/doc/1/controllers/auth/refresh-token/snippets/refresh-token-java.test.yml
@@ -5,7 +5,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/users/foo?refresh=wait_for
 template: print-result
 expected: ^{jwt=.*,\ _id=foo,\ ttl=3600000,\ expiresAt=[0-9]+}$
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/refresh-token/snippets/refresh-token-kotlin.test.yml
+++ b/doc/1/controllers/auth/refresh-token/snippets/refresh-token-kotlin.test.yml
@@ -5,7 +5,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/users/foo?refresh=wait_for
 template: print-result
 expected: ^{jwt=.*,\ _id=foo,\ ttl=3600000,\ expiresAt=[0-9]+}$
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/search-api-keys/snippets/search-api-keys-es-java.test.yml
+++ b/doc/1/controllers/auth/search-api-keys/snippets/search-api-keys-es-java.test.yml
@@ -18,7 +18,3 @@ hooks:
 template: default
 expected:
   - Found 2 API keys matching 'LoRa'
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/search-api-keys/snippets/search-api-keys-es-kotlin.test.yml
+++ b/doc/1/controllers/auth/search-api-keys/snippets/search-api-keys-es-kotlin.test.yml
@@ -18,7 +18,3 @@ hooks:
 template: default
 expected:
   - Found 2 API keys matching 'LoRa'
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/search-api-keys/snippets/search-api-keys-koncorde-java.test.yml
+++ b/doc/1/controllers/auth/search-api-keys/snippets/search-api-keys-koncorde-java.test.yml
@@ -18,7 +18,3 @@ hooks:
 template: default
 expected:
   - Found 1 API key
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/search-api-keys/snippets/search-api-keys-koncorde-kotlin.test.yml
+++ b/doc/1/controllers/auth/search-api-keys/snippets/search-api-keys-koncorde-kotlin.test.yml
@@ -18,7 +18,3 @@ hooks:
 template: default
 expected:
   - Found 1 API key
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/update-my-credentials/snippets/update-my-credentials-java.test.yml
+++ b/doc/1/controllers/auth/update-my-credentials/snippets/update-my-credentials-java.test.yml
@@ -5,7 +5,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/users/foo?refresh=wait_for
 template: print-result
 expected: {username=foo}
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/update-my-credentials/snippets/update-my-credentials-kotlin.test.yml
+++ b/doc/1/controllers/auth/update-my-credentials/snippets/update-my-credentials-kotlin.test.yml
@@ -5,7 +5,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/users/foo?refresh=wait_for
 template: print-result
 expected: {username=foo}
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/update-self/snippets/update-self-java.test.yml
+++ b/doc/1/controllers/auth/update-self/snippets/update-self-java.test.yml
@@ -5,7 +5,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/users/foo?refresh=wait_for
 template: print-result
 expected: ^{_source={profileIds=\[default\],\ _kuzzle_info={.+},\ age=42},\ _id=foo}$
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/update-self/snippets/update-self-kotlin.test.yml
+++ b/doc/1/controllers/auth/update-self/snippets/update-self-kotlin.test.yml
@@ -5,7 +5,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/users/foo?refresh=wait_for
 template: print-result
 expected: ^{_source={profileIds=\[default\],\ _kuzzle_info={.+},\ age=42},\ _id=foo}$
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/validate-my-credentials/snippets/validate-my-credentials-java.test.yml
+++ b/doc/1/controllers/auth/validate-my-credentials/snippets/validate-my-credentials-java.test.yml
@@ -5,7 +5,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/users/foo?refresh=wait_for
 template: print-result
 expected: [true]
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/auth/validate-my-credentials/snippets/validate-my-credentials-kotlin.test.yml
+++ b/doc/1/controllers/auth/validate-my-credentials/snippets/validate-my-credentials-kotlin.test.yml
@@ -5,7 +5,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/users/foo?refresh=wait_for
 template: print-result
 expected: [true]
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/bulk/delete-by-query/snippets/delete-by-query-java.test.yml
+++ b/doc/1/controllers/bulk/delete-by-query/snippets/delete-by-query-java.test.yml
@@ -18,7 +18,3 @@ hooks:
     curl -XDELETE kuzzle:7512/nyc-open-data
 template: print-result
 expected: 5
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/bulk/delete-by-query/snippets/delete-by-query-kotlin.test.yml
+++ b/doc/1/controllers/bulk/delete-by-query/snippets/delete-by-query-kotlin.test.yml
@@ -19,6 +19,3 @@ hooks:
 template: print-result
 expected: 5
 
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/bulk/import-data/snippets/import-data-java.test.yml
+++ b/doc/1/controllers/bulk/import-data/snippets/import-data-java.test.yml
@@ -7,7 +7,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/nyc-open-data
 template: print-result
 expected: 'successes=\[.*\], errors=\[\]'
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/bulk/import-data/snippets/import-data-kotlin.test.yml
+++ b/doc/1/controllers/bulk/import-data/snippets/import-data-kotlin.test.yml
@@ -7,7 +7,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/nyc-open-data
 template: print-result
 expected: 'successes=\[.*\], errors=\[\]'
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/bulk/m-write/snippets/mwrite-java.test.yml
+++ b/doc/1/controllers/bulk/m-write/snippets/mwrite-java.test.yml
@@ -7,7 +7,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/nyc-open-data
 template: print-result
 expected: 'successes=\[.*\], errors=\[\]'
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/bulk/m-write/snippets/mwrite-kotlin.test.yml
+++ b/doc/1/controllers/bulk/m-write/snippets/mwrite-kotlin.test.yml
@@ -8,6 +8,3 @@ hooks:
 template: print-result
 expected: 'successes=\[.*\], errors=\[\]'
 
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/bulk/write/snippets/write-java.test.yml
+++ b/doc/1/controllers/bulk/write/snippets/write-java.test.yml
@@ -7,7 +7,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/nyc-open-data
 template: print-result
 expected: ^{_source={_kuzzle_info={.*}}, _id=.+, _version=[0-9]+}$
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/bulk/write/snippets/write-kotlin.test.yml
+++ b/doc/1/controllers/bulk/write/snippets/write-kotlin.test.yml
@@ -7,7 +7,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/nyc-open-data
 template: print-result
 expected: ^{_source={_kuzzle_info={.*}}, _id=.+, _version=[0-9]+}$
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/collection/create/snippets/create-java.test.yml
+++ b/doc/1/controllers/collection/create/snippets/create-java.test.yml
@@ -7,6 +7,3 @@ hooks:
   after:
 template: default
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/collection/create/snippets/create-kotlin.test.yml
+++ b/doc/1/controllers/collection/create/snippets/create-kotlin.test.yml
@@ -7,6 +7,3 @@ hooks:
   after:
 template: default
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/collection/delete-specifications/snippets/delete-specifications-java.test.yml
+++ b/doc/1/controllers/collection/delete-specifications/snippets/delete-specifications-java.test.yml
@@ -5,6 +5,3 @@ hooks:
   after:
 template: default
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/collection/delete-specifications/snippets/delete-specifications-kotlin.test.yml
+++ b/doc/1/controllers/collection/delete-specifications/snippets/delete-specifications-kotlin.test.yml
@@ -5,6 +5,3 @@ hooks:
   after:
 template: default
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/collection/exists/snippets/exists-java.test.yml
+++ b/doc/1/controllers/collection/exists/snippets/exists-java.test.yml
@@ -8,6 +8,3 @@ hooks:
   after:
 template: print-result
 expected: "true"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/collection/exists/snippets/exists-kotlin.test.yml
+++ b/doc/1/controllers/collection/exists/snippets/exists-kotlin.test.yml
@@ -8,6 +8,3 @@ hooks:
   after:
 template: print-result
 expected: "true"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/collection/get-mapping/snippets/get-mapping-java.test.yml
+++ b/doc/1/controllers/collection/get-mapping/snippets/get-mapping-java.test.yml
@@ -5,6 +5,3 @@ hooks:
   after:
 template: print-result
 expected: "true"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/collection/get-mapping/snippets/get-mapping-kotlin.test.yml
+++ b/doc/1/controllers/collection/get-mapping/snippets/get-mapping-kotlin.test.yml
@@ -5,6 +5,3 @@ hooks:
   after:
 template: print-result
 expected: "true"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/collection/get-specifications/snippets/get-specifications-java.test.yml
+++ b/doc/1/controllers/collection/get-specifications/snippets/get-specifications-java.test.yml
@@ -9,6 +9,3 @@ hooks:
   after:
 template: print-result
 expected: 'fields'
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/collection/get-specifications/snippets/get-specifications-kotlin.test.yml
+++ b/doc/1/controllers/collection/get-specifications/snippets/get-specifications-kotlin.test.yml
@@ -9,6 +9,3 @@ hooks:
   after:
 template: print-result
 expected: 'fields'
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/collection/list/snippets/list-java.test.yml
+++ b/doc/1/controllers/collection/list/snippets/list-java.test.yml
@@ -5,6 +5,3 @@ hooks:
   after:
 template: default
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/collection/list/snippets/list-kotlin.test.yml
+++ b/doc/1/controllers/collection/list/snippets/list-kotlin.test.yml
@@ -5,6 +5,3 @@ hooks:
   after:
 template: default
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/collection/refresh/snippets/refresh-java.test.yml
+++ b/doc/1/controllers/collection/refresh/snippets/refresh-java.test.yml
@@ -7,6 +7,3 @@ hooks:
   after:
 template: default
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/collection/refresh/snippets/refresh-kotlin.test.yml
+++ b/doc/1/controllers/collection/refresh/snippets/refresh-kotlin.test.yml
@@ -7,6 +7,3 @@ hooks:
   after:
 template: default
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/collection/search-specifications/snippets/search-specifications-java.test.yml
+++ b/doc/1/controllers/collection/search-specifications/snippets/search-specifications-java.test.yml
@@ -15,6 +15,3 @@ hooks:
     }' kuzzle:7512/nyc-open-data/yellow-taxi/_specifications?refresh=wait_for
 template: default
 expected: 'fetched: 1'
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/collection/search-specifications/snippets/search-specifications-kotlin.test.yml
+++ b/doc/1/controllers/collection/search-specifications/snippets/search-specifications-kotlin.test.yml
@@ -15,6 +15,3 @@ hooks:
     }' kuzzle:7512/nyc-open-data/yellow-taxi/_specifications?refresh=wait_for
 template: default
 expected: 'fetched: 1'
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/collection/truncate/snippets/truncate-java.test.yml
+++ b/doc/1/controllers/collection/truncate/snippets/truncate-java.test.yml
@@ -5,6 +5,3 @@ hooks:
   after:
 template: default
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/collection/truncate/snippets/truncate-kotlin.test.yml
+++ b/doc/1/controllers/collection/truncate/snippets/truncate-kotlin.test.yml
@@ -5,6 +5,3 @@ hooks:
   after:
 template: default
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/collection/update-specifications/snippets/update-specifications-java.test.yml
+++ b/doc/1/controllers/collection/update-specifications/snippets/update-specifications-java.test.yml
@@ -7,6 +7,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/nyc-open-data/yellow-taxi/_specifications
 template: default
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/collection/update-specifications/snippets/update-specifications-kotlin.test.yml
+++ b/doc/1/controllers/collection/update-specifications/snippets/update-specifications-kotlin.test.yml
@@ -7,6 +7,3 @@ hooks:
   after: curl -X DELETE kuzzle:7512/nyc-open-data/yellow-taxi/_specifications
 template: default
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/collection/update/snippets/update-java.test.yml
+++ b/doc/1/controllers/collection/update/snippets/update-java.test.yml
@@ -5,6 +5,3 @@ hooks:
   after:
 template: default
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/collection/update/snippets/update-kotlin.test.yml
+++ b/doc/1/controllers/collection/update/snippets/update-kotlin.test.yml
@@ -5,6 +5,3 @@ hooks:
   after:
 template: default
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/collection/validate-specifications/snippets/validate-specifications-java.test.yml
+++ b/doc/1/controllers/collection/validate-specifications/snippets/validate-specifications-java.test.yml
@@ -5,6 +5,3 @@ hooks:
   after:
 template: print-result
 expected: Some errors with provided specifications.
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/collection/validate-specifications/snippets/validate-specifications-kotlin.test.yml
+++ b/doc/1/controllers/collection/validate-specifications/snippets/validate-specifications-kotlin.test.yml
@@ -5,6 +5,3 @@ hooks:
   after:
 template: print-result
 expected: Some errors with provided specifications.
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/count/snippets/count-java.test.yml
+++ b/doc/1/controllers/document/count/snippets/count-java.test.yml
@@ -16,6 +16,3 @@ hooks:
   after:
 template: print-result
 expected: 5
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/count/snippets/count-kotlin.test.yml
+++ b/doc/1/controllers/document/count/snippets/count-kotlin.test.yml
@@ -16,6 +16,3 @@ hooks:
   after:
 template: print-result
 expected: 5
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/create-or-replace/snippets/create-or-replace-java.test.yml
+++ b/doc/1/controllers/document/create-or-replace/snippets/create-or-replace-java.test.yml
@@ -8,6 +8,3 @@ hooks:
   after:
 template: print-result
 expected: "firstname=John"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/create-or-replace/snippets/create-or-replace-kotlin.test.yml
+++ b/doc/1/controllers/document/create-or-replace/snippets/create-or-replace-kotlin.test.yml
@@ -8,6 +8,3 @@ hooks:
   after:
 template: print-result
 expected: "firstname=John"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/create/snippets/create-java.test.yml
+++ b/doc/1/controllers/document/create/snippets/create-java.test.yml
@@ -8,6 +8,3 @@ hooks:
   after:
 template: print-result
 expected: "firstname=John"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/create/snippets/create-kotlin.test.yml
+++ b/doc/1/controllers/document/create/snippets/create-kotlin.test.yml
@@ -8,6 +8,3 @@ hooks:
   after:
 template: print-result
 expected: "firstname=John"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/delete-by-query/snippets/delete-by-query-es-java.test.yml
+++ b/doc/1/controllers/document/delete-by-query/snippets/delete-by-query-es-java.test.yml
@@ -20,6 +20,3 @@ expected:
   - "document_3"
   - "document_4"
   - "document_5"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/delete-by-query/snippets/delete-by-query-es-kotlin.test.yml
+++ b/doc/1/controllers/document/delete-by-query/snippets/delete-by-query-es-kotlin.test.yml
@@ -20,6 +20,3 @@ expected:
   - "document_3"
   - "document_4"
   - "document_5"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/delete-by-query/snippets/delete-by-query-koncorde-java.test.yml
+++ b/doc/1/controllers/document/delete-by-query/snippets/delete-by-query-koncorde-java.test.yml
@@ -20,7 +20,3 @@ expected:
   - "document_3"
   - "document_4"
   - "document_5"
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/delete-by-query/snippets/delete-by-query-koncorde-kotlin.test.yml
+++ b/doc/1/controllers/document/delete-by-query/snippets/delete-by-query-koncorde-kotlin.test.yml
@@ -20,7 +20,3 @@ expected:
   - "document_3"
   - "document_4"
   - "document_5"
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/delete/snippets/delete-java.test.yml
+++ b/doc/1/controllers/document/delete/snippets/delete-java.test.yml
@@ -9,6 +9,3 @@ hooks:
   after:
 template: default
 expected: ^Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/delete/snippets/delete-kotlin.test.yml
+++ b/doc/1/controllers/document/delete/snippets/delete-kotlin.test.yml
@@ -9,6 +9,3 @@ hooks:
   after:
 template: default
 expected: ^Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/exists/snippets/exists-java.test.yml
+++ b/doc/1/controllers/document/exists/snippets/exists-java.test.yml
@@ -9,6 +9,3 @@ hooks:
   after:
 template: print-result
 expected: "true"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/exists/snippets/exists-kotlin.test.yml
+++ b/doc/1/controllers/document/exists/snippets/exists-kotlin.test.yml
@@ -9,6 +9,3 @@ hooks:
   after:
 template: print-result
 expected: "true"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/get/snippets/get-java.test.yml
+++ b/doc/1/controllers/document/get/snippets/get-java.test.yml
@@ -9,6 +9,3 @@ hooks:
   after:
 template: print-result
 expected: "_id=some-id"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/get/snippets/get-kotlin.test.yml
+++ b/doc/1/controllers/document/get/snippets/get-kotlin.test.yml
@@ -9,6 +9,3 @@ hooks:
   after:
 template: print-result
 expected: "_id=some-id"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/m-create-or-replace/snippets/m-create-or-replace-java.test.yml
+++ b/doc/1/controllers/document/m-create-or-replace/snippets/m-create-or-replace-java.test.yml
@@ -10,6 +10,3 @@ template: print-result-array
 expected:
   - "id=some-id(.*)_version=1(.*)status=201"
   - "id=some-id2(.*)_version=1(.*)status=201"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/m-create-or-replace/snippets/m-create-or-replace-kotlin.test.yml
+++ b/doc/1/controllers/document/m-create-or-replace/snippets/m-create-or-replace-kotlin.test.yml
@@ -8,7 +8,3 @@ hooks:
   after:
 template: print-result-array
 expected: "id=some-id(.*)_version=1(.*)status=201(.*)id=some-id2(.*)_version=1(.*)status=201"
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/m-create/snippets/m-create-java.test.yml
+++ b/doc/1/controllers/document/m-create/snippets/m-create-java.test.yml
@@ -10,6 +10,3 @@ template: print-result-array
 expected:
   - "id=some-id(.*)_version=1(.*)status=201"
   - "id=some-id2(.*)_version=1(.*)status=201"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/m-create/snippets/m-create-kotlin.test.yml
+++ b/doc/1/controllers/document/m-create/snippets/m-create-kotlin.test.yml
@@ -8,6 +8,3 @@ hooks:
   after:
 template: print-result-array
 expected: "id=some-id(.*)_version=1(.*)status=201(.*)id=some-id2(.*)_version=1(.*)status=201"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/m-delete/snippets/m-delete-java.test.yml
+++ b/doc/1/controllers/document/m-delete/snippets/m-delete-java.test.yml
@@ -12,6 +12,3 @@ template: print-result-array
 expected:
   - "some-id"
   - "some-id2"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/m-delete/snippets/m-delete-kotlin.test.yml
+++ b/doc/1/controllers/document/m-delete/snippets/m-delete-kotlin.test.yml
@@ -10,6 +10,3 @@ hooks:
   after:
 template: print-result
 expected: "some-id, some-id2"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/m-get/snippets/m-get-java.test.yml
+++ b/doc/1/controllers/document/m-get/snippets/m-get-java.test.yml
@@ -12,6 +12,3 @@ template: print-result-array
 expected:
   - "_id=some-id(.*)_version=1"
   - "_id=some-id2(.*)_version=1"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/m-get/snippets/m-get-kotlin.test.yml
+++ b/doc/1/controllers/document/m-get/snippets/m-get-kotlin.test.yml
@@ -14,6 +14,3 @@ expected:
   - "_version=1"
   - "_id=some-id2"
   - "_version=1"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/m-replace/snippets/m-replace-java.test.yml
+++ b/doc/1/controllers/document/m-replace/snippets/m-replace-java.test.yml
@@ -12,6 +12,3 @@ template: print-result-array
 expected:
   - "id=some-id(.*)_version=2(.*)status=200"
   - "id=some-id2(.*)_version=2(.*)status=200"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/m-replace/snippets/m-replace-kotlin.test.yml
+++ b/doc/1/controllers/document/m-replace/snippets/m-replace-kotlin.test.yml
@@ -10,6 +10,3 @@ hooks:
   after:
 template: print-result
 expected: "id=some-id(.*)_version=2(.*)id=some-id2(.*)_version=2"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/m-update/snippets/m-update-java.test.yml
+++ b/doc/1/controllers/document/m-update/snippets/m-update-java.test.yml
@@ -12,6 +12,3 @@ template: print-result-array
 expected:
   - "id=some-id(.*)_version=2(.*)status=200"
   - "id=some-id2(.*)_version=2(.*)status=200"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/m-update/snippets/m-update-kotlin.test.yml
+++ b/doc/1/controllers/document/m-update/snippets/m-update-kotlin.test.yml
@@ -10,6 +10,3 @@ hooks:
   after:
 template: print-result-array
 expected: "id=some-id(.*)_version=2(.*)id=some-id2(.*)_version=2"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/replace/snippets/replace-java.test.yml
+++ b/doc/1/controllers/document/replace/snippets/replace-java.test.yml
@@ -9,6 +9,3 @@ hooks:
   after:
 template: print-result
 expected: "firstname=John"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/replace/snippets/replace-kotlin.test.yml
+++ b/doc/1/controllers/document/replace/snippets/replace-kotlin.test.yml
@@ -9,6 +9,3 @@ hooks:
   after:
 template: print-result
 expected: "firstname=John"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/search/snippets/search-es-java.test.yml
+++ b/doc/1/controllers/document/search/snippets/search-es-java.test.yml
@@ -15,7 +15,3 @@ hooks:
   after:
 template: default
 expected: ^Success
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/search/snippets/search-es-kotlin.test.yml
+++ b/doc/1/controllers/document/search/snippets/search-es-kotlin.test.yml
@@ -15,7 +15,3 @@ hooks:
   after:
 template: default
 expected: ^Success
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/search/snippets/search-koncorde-java.test.yml
+++ b/doc/1/controllers/document/search/snippets/search-koncorde-java.test.yml
@@ -15,7 +15,3 @@ hooks:
   after:
 template: default
 expected: ^Success
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/search/snippets/search-koncorde-kotlin.test.yml
+++ b/doc/1/controllers/document/search/snippets/search-koncorde-kotlin.test.yml
@@ -16,6 +16,3 @@ hooks:
 template: default
 expected: ^Success
 
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/update-by-query/snippets/update-by-query-es-java.test.yml
+++ b/doc/1/controllers/document/update-by-query/snippets/update-by-query-es-java.test.yml
@@ -17,6 +17,3 @@ template: print-result-array
 expected:
   - "id=document_1(.*)_version=2(.*)status=200"
   - "id=document_2(.*)_version=2(.*)status=200"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/update-by-query/snippets/update-by-query-es-kotlin.test.yml
+++ b/doc/1/controllers/document/update-by-query/snippets/update-by-query-es-kotlin.test.yml
@@ -15,6 +15,3 @@ hooks:
   after:
 template: print-result
 expected: "id=document_1(.*)_version=2(.*)status=200(.*)id=document_2(.*)_version=2(.*)status=200"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/update-by-query/snippets/update-by-query-koncorde-java.test.yml
+++ b/doc/1/controllers/document/update-by-query/snippets/update-by-query-koncorde-java.test.yml
@@ -17,7 +17,3 @@ template: print-result-array
 expected:
   - "id=document_1(.*)_version=2(.*)status=200"
   - "id=document_2(.*)_version=2(.*)status=200"
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/update-by-query/snippets/update-by-query-koncorde-kotlin.test.yml
+++ b/doc/1/controllers/document/update-by-query/snippets/update-by-query-koncorde-kotlin.test.yml
@@ -15,6 +15,3 @@ hooks:
   after:
 template: print-result
 expected: "id=document_1(.*)_version=2(.*)status=200(.*)id=document_2(.*)_version=2(.*)status=200"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/update/snippets/update-java.test.yml
+++ b/doc/1/controllers/document/update/snippets/update-java.test.yml
@@ -9,6 +9,3 @@ hooks:
   after:
 template: print-result
 expected: "_id=some-id(.*)_version=2"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/update/snippets/update-kotlin.test.yml
+++ b/doc/1/controllers/document/update/snippets/update-kotlin.test.yml
@@ -9,7 +9,3 @@ hooks:
   after:
 template: print-result
 expected: "_id=some-id(.*)_version=2"
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/upsert/snippets/upsert-java.test.yml
+++ b/doc/1/controllers/document/upsert/snippets/upsert-java.test.yml
@@ -8,6 +8,3 @@ hooks:
   after:
 template: print-result
 expected: "{created=true, _id=some-id, _version=1}"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/upsert/snippets/upsert-kotlin.test.yml
+++ b/doc/1/controllers/document/upsert/snippets/upsert-kotlin.test.yml
@@ -8,6 +8,3 @@ hooks:
   after:
 template: print-result
 expected: "{created=true, _id=some-id, _version=1}"
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/validate/snippets/validate-java.test.yml
+++ b/doc/1/controllers/document/validate/snippets/validate-java.test.yml
@@ -8,6 +8,3 @@ hooks:
   after:
 template: print-result
 expected: true
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/document/validate/snippets/validate-kotlin.test.yml
+++ b/doc/1/controllers/document/validate/snippets/validate-kotlin.test.yml
@@ -8,6 +8,3 @@ hooks:
   after:
 template: print-result
 expected: true
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/index/create/snippets/create-java.test.yml
+++ b/doc/1/controllers/index/create/snippets/create-java.test.yml
@@ -6,6 +6,3 @@ hooks:
   after:
 template: default
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/index/create/snippets/create-kotlin.test.yml
+++ b/doc/1/controllers/index/create/snippets/create-kotlin.test.yml
@@ -6,6 +6,3 @@ hooks:
   after:
 template: default
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/index/delete/snippets/delete-java.test.yml
+++ b/doc/1/controllers/index/delete/snippets/delete-java.test.yml
@@ -6,6 +6,3 @@ hooks:
   after:
 template: default
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/index/delete/snippets/delete-kotlin.test.yml
+++ b/doc/1/controllers/index/delete/snippets/delete-kotlin.test.yml
@@ -6,6 +6,3 @@ hooks:
   after:
 template: default
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/index/exists/snippets/exists-java.test.yml
+++ b/doc/1/controllers/index/exists/snippets/exists-java.test.yml
@@ -6,6 +6,3 @@ hooks:
   after:
 template: print-result
 expected: true
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/index/exists/snippets/exists-kotlin.test.yml
+++ b/doc/1/controllers/index/exists/snippets/exists-kotlin.test.yml
@@ -6,6 +6,3 @@ hooks:
   after:
 template: print-result
 expected: true
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/index/list/snippets/list-java.test.yml
+++ b/doc/1/controllers/index/list/snippets/list-java.test.yml
@@ -8,7 +8,3 @@ hooks:
   after:
 template: print-result
 expected: ["nyc-open-data"]
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/index/list/snippets/list-kotlin.test.yml
+++ b/doc/1/controllers/index/list/snippets/list-kotlin.test.yml
@@ -8,7 +8,3 @@ hooks:
   after:
 template: print-result
 expected: ["nyc-open-data"]
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/index/m-delete/snippets/mDelete-java.test.yml
+++ b/doc/1/controllers/index/m-delete/snippets/mDelete-java.test.yml
@@ -6,6 +6,3 @@ hooks:
   after:
 template: print-result
 expected: ["nyc-open-data"]
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/index/m-delete/snippets/mDelete-kotlin.test.yml
+++ b/doc/1/controllers/index/m-delete/snippets/mDelete-kotlin.test.yml
@@ -6,6 +6,3 @@ hooks:
   after:
 template: print-result
 expected: ["nyc-open-data"]
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/realtime/count/snippets/count-java.test.yml
+++ b/doc/1/controllers/realtime/count/snippets/count-java.test.yml
@@ -5,6 +5,3 @@ hooks:
   after:
 template: print-result
 expected: 1
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/realtime/count/snippets/count-kotlin.test.yml
+++ b/doc/1/controllers/realtime/count/snippets/count-kotlin.test.yml
@@ -5,6 +5,3 @@ hooks:
   after:
 template: print-result
 expected: 1
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/realtime/publish/snippets/publish-java.test.yml
+++ b/doc/1/controllers/realtime/publish/snippets/publish-java.test.yml
@@ -5,6 +5,3 @@ hooks:
   after:
 template: default
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/realtime/publish/snippets/publish-kotlin.test.yml
+++ b/doc/1/controllers/realtime/publish/snippets/publish-kotlin.test.yml
@@ -5,6 +5,3 @@ hooks:
   after:
 template: default
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/realtime/subscribe/snippets/document-notifications-java.test.yml
+++ b/doc/1/controllers/realtime/subscribe/snippets/document-notifications-java.test.yml
@@ -9,5 +9,4 @@ hooks:
 template: default
 expected: Document entered the scope
 protocols:
-  - http
   - websocket

--- a/doc/1/controllers/realtime/subscribe/snippets/document-notifications-kotlin.test.yml
+++ b/doc/1/controllers/realtime/subscribe/snippets/document-notifications-kotlin.test.yml
@@ -9,5 +9,4 @@ hooks:
 template: default
 expected: Document entered the scope
 protocols:
-  - http
   - websocket

--- a/doc/1/controllers/realtime/subscribe/snippets/document-notifications-leave-scope-java.test.yml
+++ b/doc/1/controllers/realtime/subscribe/snippets/document-notifications-leave-scope-java.test.yml
@@ -9,5 +9,4 @@ hooks:
 template: default
 expected: Document\ moved\ in\ the\ scope
 protocols:
-  - http
   - websocket

--- a/doc/1/controllers/realtime/subscribe/snippets/document-notifications-leave-scope-kotlin.test.yml
+++ b/doc/1/controllers/realtime/subscribe/snippets/document-notifications-leave-scope-kotlin.test.yml
@@ -9,5 +9,4 @@ hooks:
 template: default
 expected: Document\ moved\ in\ the\ scope
 protocols:
-  - http
   - websocket

--- a/doc/1/controllers/realtime/unsubscribe/snippets/unsubscribe-java.test.yml
+++ b/doc/1/controllers/realtime/unsubscribe/snippets/unsubscribe-java.test.yml
@@ -6,5 +6,4 @@ hooks:
 template: default
 expected: Success
 protocols:
-  - http
   - websocket

--- a/doc/1/controllers/realtime/unsubscribe/snippets/unsubscribe-kotlin.test.yml
+++ b/doc/1/controllers/realtime/unsubscribe/snippets/unsubscribe-kotlin.test.yml
@@ -6,5 +6,4 @@ hooks:
 template: default
 expected: Success
 protocols:
-  - http
   - websocket

--- a/doc/1/controllers/server/admin-exists/snippets/admin-exists-java.test.yml
+++ b/doc/1/controllers/server/admin-exists/snippets/admin-exists-java.test.yml
@@ -5,6 +5,3 @@ hooks:
   after:
 template: print-result
 expected: false
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/server/admin-exists/snippets/admin-exists-kotlin.test.yml
+++ b/doc/1/controllers/server/admin-exists/snippets/admin-exists-kotlin.test.yml
@@ -5,6 +5,3 @@ hooks:
   after:
 template: print-result
 expected: false
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/server/get-all-stats/snippets/get-all-stats-java.test.yml
+++ b/doc/1/controllers/server/get-all-stats/snippets/get-all-stats-java.test.yml
@@ -5,7 +5,3 @@ hooks:
   after:
 template: print-result
 expected: ongoingRequests
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/server/get-all-stats/snippets/get-all-stats-kotlin.test.yml
+++ b/doc/1/controllers/server/get-all-stats/snippets/get-all-stats-kotlin.test.yml
@@ -5,7 +5,3 @@ hooks:
   after:
 template: print-result
 expected: ongoingRequests
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/server/get-config/snippets/get-config-java.test.yml
+++ b/doc/1/controllers/server/get-config/snippets/get-config-java.test.yml
@@ -5,6 +5,3 @@ hooks:
   after:
 template: print-result
 expected: ^{server={.*}$
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/server/get-config/snippets/get-config-kotlin.test.yml
+++ b/doc/1/controllers/server/get-config/snippets/get-config-kotlin.test.yml
@@ -5,6 +5,3 @@ hooks:
   after:
 template: print-result
 expected: ^{server={.*}$
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/server/get-last-stats/snippets/get-last-stats-java.test.yml
+++ b/doc/1/controllers/server/get-last-stats/snippets/get-last-stats-java.test.yml
@@ -5,7 +5,3 @@ hooks:
   after:
 template: print-result
 expected: ongoingRequests
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/server/get-last-stats/snippets/get-last-stats-kotlin.test.yml
+++ b/doc/1/controllers/server/get-last-stats/snippets/get-last-stats-kotlin.test.yml
@@ -5,7 +5,3 @@ hooks:
   after:
 template: print-result
 expected: ongoingRequests
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/server/get-stats/snippets/get-stats-java.test.yml
+++ b/doc/1/controllers/server/get-stats/snippets/get-stats-java.test.yml
@@ -5,7 +5,3 @@ hooks:
   after:
 template: print-result
 expected: hits
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/server/get-stats/snippets/get-stats-kotlin.test.yml
+++ b/doc/1/controllers/server/get-stats/snippets/get-stats-kotlin.test.yml
@@ -5,7 +5,3 @@ hooks:
   after:
 template: print-result
 expected: hits
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/server/info/snippets/info-java.test.yml
+++ b/doc/1/controllers/server/info/snippets/info-java.test.yml
@@ -5,7 +5,3 @@ hooks:
   after:
 template: print-result
 expected: serverInfo
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/server/info/snippets/info-kotlin.test.yml
+++ b/doc/1/controllers/server/info/snippets/info-kotlin.test.yml
@@ -5,7 +5,3 @@ hooks:
   after:
 template: print-result
 expected: serverInfo
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/server/now/snippets/now-java.test.yml
+++ b/doc/1/controllers/server/now/snippets/now-java.test.yml
@@ -5,6 +5,3 @@ hooks:
   after:
 template: print-result
 exptected: (([0-1]?[0-9])|(2[0-3])):[0-5][0-9]:[0-5][0-9]
-protocols:
-  - http
-  - websocket

--- a/doc/1/controllers/server/now/snippets/now-kotlin.test.yml
+++ b/doc/1/controllers/server/now/snippets/now-kotlin.test.yml
@@ -5,7 +5,3 @@ hooks:
   after:
 template: print-result
 expected: (([0-1]?[0-9])|(2[0-3])):[0-5][0-9]:[0-5][0-9]
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/core-classes/kuzzle/connect/snippets/connect-java.test.yml
+++ b/doc/1/core-classes/kuzzle/connect/snippets/connect-java.test.yml
@@ -6,7 +6,3 @@ hooks:
   after:
 template: without-connect
 expected: Success
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/core-classes/kuzzle/connect/snippets/connect-kotlin.test.yml
+++ b/doc/1/core-classes/kuzzle/connect/snippets/connect-kotlin.test.yml
@@ -6,7 +6,3 @@ hooks:
   after:
 template: without-connect
 expected: Success
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/core-classes/kuzzle/constructor/snippets/constructor-java.test.yml
+++ b/doc/1/core-classes/kuzzle/constructor/snippets/constructor-java.test.yml
@@ -6,6 +6,3 @@ hooks:
   after:
 template: without-ctor
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/core-classes/kuzzle/constructor/snippets/constructor-kotlin.test.yml
+++ b/doc/1/core-classes/kuzzle/constructor/snippets/constructor-kotlin.test.yml
@@ -6,6 +6,3 @@ hooks:
   after:
 template: without-ctor
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/core-classes/kuzzle/disconnect/snippets/disconnect-java.test.yml
+++ b/doc/1/core-classes/kuzzle/disconnect/snippets/disconnect-java.test.yml
@@ -6,6 +6,3 @@ hooks:
   after:
 template: default
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/core-classes/kuzzle/disconnect/snippets/disconnect-kotlin.test.yml
+++ b/doc/1/core-classes/kuzzle/disconnect/snippets/disconnect-kotlin.test.yml
@@ -6,6 +6,3 @@ hooks:
   after:
 template: default
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/core-classes/kuzzle/query/snippets/query-java.test.yml
+++ b/doc/1/core-classes/kuzzle/query/snippets/query-java.test.yml
@@ -9,6 +9,3 @@ hooks:
   after:
 template: default
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/core-classes/kuzzle/query/snippets/query-kotlin.test.yml
+++ b/doc/1/core-classes/kuzzle/query/snippets/query-kotlin.test.yml
@@ -9,6 +9,3 @@ hooks:
   after:
 template: default
 expected: Success
-protocols:
-  - http
-  - websocket

--- a/doc/1/core-classes/search-result/next/snippets/fromsize-java.test.yml
+++ b/doc/1/core-classes/search-result/next/snippets/fromsize-java.test.yml
@@ -14,6 +14,3 @@ hooks:
     curl -XDELETE kuzzle:7512/nyc-open-data
 template: print-search-result
 expected: Successfully retrieved 100 documents
-protocols:
-  - http
-  - websocket

--- a/doc/1/core-classes/search-result/next/snippets/fromsize-kotlin.test.yml
+++ b/doc/1/core-classes/search-result/next/snippets/fromsize-kotlin.test.yml
@@ -14,6 +14,3 @@ hooks:
     curl -XDELETE kuzzle:7512/nyc-open-data
 template: print-search-result
 expected: Successfully retrieved 100 documents
-protocols:
-  - http
-  - websocket

--- a/doc/1/core-classes/search-result/next/snippets/scroll-java.test.yml
+++ b/doc/1/core-classes/search-result/next/snippets/scroll-java.test.yml
@@ -14,6 +14,3 @@ hooks:
     curl -XDELETE kuzzle:7512/nyc-open-data
 template: print-search-result
 expected: Successfully retrieved 100 documents
-protocols:
-  - http
-  - websocket

--- a/doc/1/core-classes/search-result/next/snippets/scroll-kotlin.test.yml
+++ b/doc/1/core-classes/search-result/next/snippets/scroll-kotlin.test.yml
@@ -15,6 +15,3 @@ hooks:
     curl -XDELETE kuzzle:7512/nyc-open-data
 template: print-search-result
 expected: Successfully retrieved 100 documents
-protocols:
-  - http
-  - websocket

--- a/doc/1/getting-started/java/snippets/document-java.test.yml
+++ b/doc/1/getting-started/java/snippets/document-java.test.yml
@@ -7,6 +7,3 @@ template: empty
 expected:
   - Connected!
   - New document added to the yellow-taxi collection!
-protocols:
-  - http
-  - websocket

--- a/doc/1/getting-started/java/snippets/firstconnection-java.test.yml
+++ b/doc/1/getting-started/java/snippets/firstconnection-java.test.yml
@@ -8,7 +8,3 @@ expected:
   - Connected!
   - Index nyc-open-data created!
   - Collection yellow-taxi created!
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/getting-started/java/snippets/realtime-java.test.yml
+++ b/doc/1/getting-started/java/snippets/realtime-java.test.yml
@@ -8,7 +8,3 @@ expected:
   - Connected!
   - Successfully subscribed!
   - ^New created document notification:.*$
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/getting-started/kotlin/snippets/document-kotlin.test.yml
+++ b/doc/1/getting-started/kotlin/snippets/document-kotlin.test.yml
@@ -7,6 +7,3 @@ template: empty
 expected:
   - Connected!
   - New document added to the yellow-taxi collection!
-protocols:
-  - http
-  - websocket

--- a/doc/1/getting-started/kotlin/snippets/firstconnection-kotlin.test.yml
+++ b/doc/1/getting-started/kotlin/snippets/firstconnection-kotlin.test.yml
@@ -8,7 +8,3 @@ expected:
   - Connected!
   - Index nyc-open-data created!
   - Collection yellow-taxi created!
-
-protocols:
-  - http
-  - websocket

--- a/doc/1/getting-started/kotlin/snippets/realtime-kotlin.test.yml
+++ b/doc/1/getting-started/kotlin/snippets/realtime-kotlin.test.yml
@@ -8,7 +8,3 @@ expected:
   - Connected!
   - Successfully subscribed!
   - ^New created document notification:.*$
-
-protocols:
-  - http
-  - websocket

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/io/kuzzle/sdk/controllers/AuthController.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/controllers/AuthController.kt
@@ -150,9 +150,9 @@ class AuthController(kuzzle: Kuzzle) : BaseController(kuzzle) {
                 .from(response.result as Map<String?, Any?>)
             kuzzle.authenticationToken = map.getString("jwt")
             if (map.getString("_id") != null) {
-                kuzzle.protocol.trigger("loginAttempt", "true")
+                kuzzle.protocol.trigger("loginAttempt", arrayOf("true"))
             } else {
-                kuzzle.protocol.trigger("loginAttempt", "false")
+                kuzzle.protocol.trigger("loginAttempt", arrayOf("false"))
             }
             map as Map<String, Any?>
         }

--- a/src/main/kotlin/io/kuzzle/sdk/controllers/AuthController.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/controllers/AuthController.kt
@@ -5,6 +5,7 @@ import io.kuzzle.sdk.coreClasses.SearchResult
 import io.kuzzle.sdk.coreClasses.lang.Lang
 import io.kuzzle.sdk.coreClasses.maps.KuzzleMap
 import io.kuzzle.sdk.coreClasses.responses.Response
+import io.kuzzle.sdk.events.LoginAttemptEvent
 import java.util.concurrent.CompletableFuture
 
 class AuthController(kuzzle: Kuzzle) : BaseController(kuzzle) {
@@ -150,9 +151,9 @@ class AuthController(kuzzle: Kuzzle) : BaseController(kuzzle) {
                 .from(response.result as Map<String?, Any?>)
             kuzzle.authenticationToken = map.getString("jwt")
             if (map.getString("_id") != null) {
-                kuzzle.protocol.trigger("loginAttempt", arrayOf("true"))
+                kuzzle.protocol.trigger(LoginAttemptEvent(true))
             } else {
-                kuzzle.protocol.trigger("loginAttempt", arrayOf("false"))
+                kuzzle.protocol.trigger(LoginAttemptEvent(false))
             }
             map as Map<String, Any?>
         }

--- a/src/main/kotlin/io/kuzzle/sdk/events/EventManager.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/events/EventManager.kt
@@ -1,13 +1,13 @@
 package io.kuzzle.sdk.events
 
 open class EventManager {
-    private val listeners: HashMap<String, (String?) -> Unit> = HashMap()
+    private val listeners: HashMap<String, (Array<Any?>?) -> Unit> = HashMap()
 
-    fun addListener(event: String, listener: (String?) -> Unit) {
+    fun addListener(event: String, listener: (Array<Any?>?) -> Unit) {
         listeners[event] = listener
     }
 
-    fun trigger(event: String, message: String? = null) {
-        listeners[event]?.invoke(message)
+    fun trigger(event: String, args: Array<Any?>?) {
+        listeners[event]?.invoke(args)
     }
 }

--- a/src/main/kotlin/io/kuzzle/sdk/events/EventManager.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/events/EventManager.kt
@@ -1,13 +1,35 @@
 package io.kuzzle.sdk.events
 
 open class EventManager {
-    private val listeners: HashMap<String, (Array<Any?>?) -> Unit> = HashMap()
+    val listeners: HashMap<Any, Any> = HashMap()
 
-    fun addListener(event: String, listener: (Array<Any?>?) -> Unit) {
-        listeners[event] = listener
+    // Java version of addListener function
+    fun <T : IEvent> addListener(eventClass: Class<T>, listener: (T) -> Unit) {
+        if (listeners[eventClass] == null) {
+            listeners[eventClass] = mutableListOf(listener)
+        } else {
+            var list = listeners[eventClass] as MutableList<Any>
+            list.add(listener)
+        }
     }
 
-    fun trigger(event: String, args: Array<Any?>?) {
-        listeners[event]?.invoke(args)
+    // Kotlin version of addListener function
+    inline fun <reified T : IEvent> addListener(noinline listener: (T) -> Unit) {
+        if (listeners[T::class.java] == null) {
+            listeners[T::class.java] = mutableListOf(listener)
+        } else {
+            var list = listeners[T::class.java] as MutableList<Any>
+            list.add(listener)
+        }
+    }
+
+    // Kotlin version of trigger function, no need for Java version since
+    internal inline fun <reified T : IEvent> trigger(event: T) {
+        if (listeners[T::class.java] != null) {
+            var invokerList = listeners[T::class.java] as MutableList<(T) -> Unit>
+            for (invokable: (T) -> Unit in invokerList) {
+                invokable.invoke(event)
+            }
+        }
     }
 }

--- a/src/main/kotlin/io/kuzzle/sdk/events/IEvent.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/events/IEvent.kt
@@ -1,0 +1,4 @@
+package io.kuzzle.sdk.events
+
+interface IEvent {
+}

--- a/src/main/kotlin/io/kuzzle/sdk/events/IEvent.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/events/IEvent.kt
@@ -1,4 +1,9 @@
 package io.kuzzle.sdk.events
 
-interface IEvent {
+abstract class IEvent {
+    var eventId: Int
+
+    constructor(eventId: Int) {
+        this.eventId = eventId
+    }
 }

--- a/src/main/kotlin/io/kuzzle/sdk/events/LoginAttemptEvent.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/events/LoginAttemptEvent.kt
@@ -1,0 +1,4 @@
+package io.kuzzle.sdk.events
+
+class LoginAttemptEvent {
+}

--- a/src/main/kotlin/io/kuzzle/sdk/events/LoginAttemptEvent.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/events/LoginAttemptEvent.kt
@@ -1,4 +1,8 @@
 package io.kuzzle.sdk.events
 
-class LoginAttemptEvent {
+class LoginAttemptEvent : IEvent {
+    var success: Boolean
+    constructor(success: Boolean) : super(0) {
+        this.success = success
+    }
 }

--- a/src/main/kotlin/io/kuzzle/sdk/events/MessageReceivedEvent.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/events/MessageReceivedEvent.kt
@@ -1,4 +1,10 @@
 package io.kuzzle.sdk.events
 
-class MessageReceivedEvent {
+class MessageReceivedEvent : IEvent {
+    var message: String?
+    var requestId: String?
+    constructor(message: String?, requestId: String?) : super(1) {
+        this.message = message
+        this.requestId = requestId
+    }
 }

--- a/src/main/kotlin/io/kuzzle/sdk/events/MessageReceivedEvent.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/events/MessageReceivedEvent.kt
@@ -1,0 +1,4 @@
+package io.kuzzle.sdk.events
+
+class MessageReceivedEvent {
+}

--- a/src/main/kotlin/io/kuzzle/sdk/events/NetworkStateChangeEvent.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/events/NetworkStateChangeEvent.kt
@@ -1,4 +1,10 @@
 package io.kuzzle.sdk.events
 
-class NetworkStateChangeEvent {
+import io.kuzzle.sdk.protocol.ProtocolState
+
+class NetworkStateChangeEvent : IEvent {
+    var state: ProtocolState
+    constructor(state: ProtocolState) : super(2) {
+        this.state = state
+    }
 }

--- a/src/main/kotlin/io/kuzzle/sdk/events/NetworkStateChangeEvent.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/events/NetworkStateChangeEvent.kt
@@ -1,0 +1,4 @@
+package io.kuzzle.sdk.events
+
+class NetworkStateChangeEvent {
+}

--- a/src/main/kotlin/io/kuzzle/sdk/events/TokenExpiredEvent.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/events/TokenExpiredEvent.kt
@@ -1,4 +1,3 @@
 package io.kuzzle.sdk.events
 
-class TokenExpiredEvent {
-}
+class TokenExpiredEvent : IEvent(3) {}

--- a/src/main/kotlin/io/kuzzle/sdk/events/TokenExpiredEvent.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/events/TokenExpiredEvent.kt
@@ -1,0 +1,4 @@
+package io.kuzzle.sdk.events
+
+class TokenExpiredEvent {
+}

--- a/src/main/kotlin/io/kuzzle/sdk/events/UnhandledResponseEvent.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/events/UnhandledResponseEvent.kt
@@ -1,0 +1,4 @@
+package io.kuzzle.sdk.events
+
+class UnhandledResponseEvent {
+}

--- a/src/main/kotlin/io/kuzzle/sdk/events/UnhandledResponseEvent.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/events/UnhandledResponseEvent.kt
@@ -1,4 +1,8 @@
 package io.kuzzle.sdk.events
 
-class UnhandledResponseEvent {
+class UnhandledResponseEvent : IEvent {
+    var message: String?
+    constructor(message: String?) : super(4) {
+        this.message = message
+    }
 }

--- a/src/main/kotlin/io/kuzzle/sdk/protocol/Http.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/protocol/Http.kt
@@ -29,7 +29,7 @@ open class Http : AbstractProtocol {
 
     override fun connect () {
         if (this.state == ProtocolState.OPEN) {
-            trigger("networkStateChange", ProtocolState.OPEN.toString())
+            trigger("networkStateChange", arrayOf(ProtocolState.OPEN.toString()))
             return
         }
         // if state is NOT open, return response to /_publicApi
@@ -42,7 +42,7 @@ open class Http : AbstractProtocol {
 
     override fun disconnect () {
         this.state = ProtocolState.CLOSE
-        trigger("networkStateChange", ProtocolState.CLOSE.toString())
+        trigger("networkStateChange", arrayOf(ProtocolState.CLOSE.toString()))
     }
 
     override fun send (payload: Map<String?, Any?>) {
@@ -63,14 +63,8 @@ open class Http : AbstractProtocol {
               HttpResponse.BodyHandlers.ofString()
             ).body().toString()
 
-            // get initial requestId
-            var tmp = mutableMapOf<String?, Any?>()
-            for ((k, v) in JsonSerializer.deserialize(response) as Map<String?, Any?>) {
-                tmp.put(k, v)
-            }
-            tmp["requestId"] = payload.get("requestId")
             // trigger messageReceived
-            super.trigger("messageReceived", JsonSerializer.serialize(tmp))
+            super.trigger("messageReceived", arrayOf(response, payload.get("requestId") as String?))
         }
     }
 }

--- a/src/main/kotlin/io/kuzzle/sdk/protocol/Http.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/protocol/Http.kt
@@ -1,15 +1,18 @@
 package io.kuzzle.sdk.protocol
 
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.kuzzle.sdk.coreClasses.json.JsonSerializer
-import java.net.URI
-import java.net.http.HttpClient
-import java.net.http.HttpRequest
-import java.net.http.HttpResponse
+import io.kuzzle.sdk.events.MessageReceivedEvent
+import io.kuzzle.sdk.events.NetworkStateChangeEvent
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import java.util.concurrent.CompletableFuture
 
 open class Http : AbstractProtocol {
-    override var state: ProtocolState = ProtocolState.OPEN
-    private val request = HttpRequest.newBuilder()
-    private val client = HttpClient.newBuilder().build()
+    override var state: ProtocolState = ProtocolState.CLOSE
     private var uri: String
 
     @JvmOverloads
@@ -23,48 +26,61 @@ open class Http : AbstractProtocol {
       } else {
         this.uri = "https://${host}:${port}/_query"
       }
-      this.request.uri(URI.create(this.uri))
-      this.state = ProtocolState.OPEN
     }
 
     override fun connect () {
-        if (this.state == ProtocolState.OPEN) {
-            trigger("networkStateChange", arrayOf(ProtocolState.OPEN.toString()))
+        if (this.state != ProtocolState.CLOSE) {
             return
         }
-        // if state is NOT open, return response to /_publicApi
-        this.request.uri(URI.create("http://localhost:7512/_publicApi"))
-        val response = client.send(request.build(), HttpResponse.BodyHandlers.ofString())
-        if (response.statusCode() == 401 || response.statusCode() == 403) {
-            throw Exception("You must have permission on the _query route.")
+
+        val wait = CompletableFuture<Void>()
+        // if state is NOT open, request /_query to see if we have the proper rights to make request using _query
+        GlobalScope.launch {
+
+            var client = HttpClient()
+            var response: HttpResponse = client.post(uri) {
+                this.header("content-type", "application/json")
+                this.body = "{}"
+            }
+            client.close()
+            if (response.status.value == 401 || response.status.value == 403) {
+                wait.completeExceptionally(java.lang.Exception("You must have permission on the _query route."))
+                return@launch
+            }
+            wait.complete(null)
         }
+
+        wait.get()
+
+        this.state = ProtocolState.OPEN
+        trigger(NetworkStateChangeEvent(ProtocolState.OPEN))
     }
 
     override fun disconnect () {
+        if (state != ProtocolState.OPEN) {
+            return
+        }
+
         this.state = ProtocolState.CLOSE
-        trigger("networkStateChange", arrayOf(ProtocolState.CLOSE.toString()))
+        trigger(NetworkStateChangeEvent(ProtocolState.CLOSE))
     }
 
     override fun send (payload: Map<String?, Any?>) {
-        if (payload["requestId"] != null) {
-            // Create header
-            this.request.header("Content-Type", "application/json")
-            // Get jwt
-            if (payload["jwt"] != null) {
-                this.request.header("Authorization", "Bearer ${payload["jwt"]}")
+        GlobalScope.launch { // Launch HTTP Request inside a coroutine to be non-blocking
+            var client = HttpClient()
+            var response: HttpResponse = client.post(uri) {
+                this.header("content-type", "application/json")
+                if (payload["jwt"] != null) {
+                    this.header("Authorization", "Bearer ${payload["jwt"]}")
+                }
+                if (payload["volatile"] != null) {
+                    this.header("Volatile", "${payload["volatile"]}")
+                }
+                this.body = JsonSerializer.serialize(payload)
             }
-            // Get volatile
-            if (payload["volatile"] != null) {
-                this.request.header("Volatile", "${payload["volatile"]}")
-            }
-            // Send request
-            var response = client.send(
-              request.POST(HttpRequest.BodyPublishers.ofString(JsonSerializer.serialize(payload))).build(),
-              HttpResponse.BodyHandlers.ofString()
-            ).body().toString()
-
+            client.close()
             // trigger messageReceived
-            super.trigger("messageReceived", arrayOf(response, payload.get("requestId") as String?))
+            super.trigger(MessageReceivedEvent(response.receive(), payload["requestId"] as String?))
         }
     }
 }

--- a/src/main/kotlin/io/kuzzle/sdk/protocol/ProtocolState.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/protocol/ProtocolState.kt
@@ -1,7 +1,7 @@
 package io.kuzzle.sdk.protocol
 
-enum class ProtocolState {
-    CLOSE, // The network protocol does not accept requests.
-    OPEN, // The network protocol accepts new requests.
-    RECONNECTING // The nerwork protocol is trying to reconnect
+enum class ProtocolState(val value: Int) {
+    CLOSE(0), // The network protocol does not accept requests.
+    OPEN(1), // The network protocol accepts new requests.
+    RECONNECTING(2) // The nerwork protocol is trying to reconnect
 }

--- a/src/main/kotlin/io/kuzzle/sdk/protocol/WebSocket.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/protocol/WebSocket.kt
@@ -12,8 +12,9 @@ import io.ktor.http.cio.websocket.Frame
 import io.ktor.http.cio.websocket.close
 import io.ktor.http.cio.websocket.readBytes
 import io.ktor.http.cio.websocket.readText
-import io.ktor.util.KtorExperimentalAPI
 import io.kuzzle.sdk.coreClasses.json.JsonSerializer
+import io.kuzzle.sdk.events.MessageReceivedEvent
+import io.kuzzle.sdk.events.NetworkStateChangeEvent
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import java.io.IOException
@@ -36,14 +37,7 @@ open class WebSocket : AbstractProtocol {
     private val reconnectionRetries: Long
     private val stopRetryingToConnect: AtomicBoolean = AtomicBoolean(false)
 
-    @KtorExperimentalAPI
-    protected open var client = HttpClient {
-        install(WebSockets)
-        install(JsonFeature) {
-            serializer = GsonSerializer()
-            acceptContentTypes += ContentType("application", "json")
-        }
-    }
+    protected open var client: HttpClient? = null
 
     @JvmOverloads
     constructor(
@@ -62,13 +56,12 @@ open class WebSocket : AbstractProtocol {
         this.reconnectionRetries = reconnectionRetries
     }
 
-    @KtorExperimentalAPI
     private fun tryToReconnect(): CompletableFuture<Boolean> {
         if (!autoReconnect || this.stopRetryingToConnect.get())
             return CompletableFuture.completedFuture(false)
 
         state = ProtocolState.RECONNECTING
-        trigger("networkStateChange", arrayOf(state.toString()))
+        trigger(NetworkStateChangeEvent(state))
         return CompletableFuture.supplyAsync(
             fun(): Boolean {
                 var retryCount: Long = 0
@@ -91,17 +84,30 @@ open class WebSocket : AbstractProtocol {
         )
     }
 
-    @KtorExperimentalAPI
     override fun connect() {
+        if (this.state == ProtocolState.OPEN) {
+            return
+        }
+
         if (this.stopRetryingToConnect.get())
             throw Exception("Connection Aborted")
+
+        if (this.state == ProtocolState.CLOSE) {
+            client = HttpClient {
+                install(WebSockets)
+                install(JsonFeature) {
+                    serializer = GsonSerializer()
+                    acceptContentTypes += ContentType("application", "json")
+                }
+            }
+        }
 
         val wait = CompletableFuture<Void>()
         val block: suspend DefaultClientWebSocketSession.() -> Unit = {
             ws = this
             // @TODO Create enums for events
             state = ProtocolState.OPEN
-            trigger("networkStateChange", arrayOf(ProtocolState.OPEN.toString()))
+            trigger(NetworkStateChangeEvent(ProtocolState.OPEN))
 
             thread(start = true) {
                 while (ws != null) {
@@ -119,9 +125,9 @@ open class WebSocket : AbstractProtocol {
                 for (frame in incoming) {
                     when (frame) {
                         // @TODO Create enums for events
-                        is Frame.Text -> super.trigger("messageReceived", arrayOf(frame.readText()))
+                        is Frame.Text -> super.trigger(MessageReceivedEvent(frame.readText(), null))
                         // @TODO Create enums for events
-                        is Frame.Binary -> super.trigger("messageReceived", arrayOf(frame.readBytes().toString()))
+                        is Frame.Binary -> super.trigger(MessageReceivedEvent(frame.readBytes().toString(), null))
                     }
                 }
             } catch (e: Exception) {
@@ -130,7 +136,7 @@ open class WebSocket : AbstractProtocol {
                     fun (success: Boolean) {
                         if (!success) {
                             state = ProtocolState.CLOSE
-                            trigger("networkStateChange", arrayOf(ProtocolState.CLOSE.toString()))
+                            trigger(NetworkStateChangeEvent(ProtocolState.CLOSE))
                             ws = null
                         }
                         // reset stopRetryingToConnect
@@ -140,23 +146,23 @@ open class WebSocket : AbstractProtocol {
             }
             if (!skip) {
                 state = ProtocolState.CLOSE
-                trigger("networkStateChange", arrayOf(ProtocolState.CLOSE.toString()))
+                trigger(NetworkStateChangeEvent(ProtocolState.CLOSE))
                 ws = null
             }
         }
         GlobalScope.launch {
             try {
                 if (isSsl) {
-                    client.wss(
-                        host = this@WebSocket.host,
-                        port = this@WebSocket.port,
-                        block = block
+                    client?.wss(
+                            host = this@WebSocket.host,
+                            port = this@WebSocket.port,
+                            block = block
                     )
                 } else {
-                    client.ws(
-                        host = this@WebSocket.host,
-                        port = this@WebSocket.port,
-                        block = block
+                    client?.ws(
+                            host = this@WebSocket.host,
+                            port = this@WebSocket.port,
+                            block = block
                     )
                 }
 
@@ -167,7 +173,7 @@ open class WebSocket : AbstractProtocol {
                 // In Kotlin this is handled by the block function above but for some reason in JAVA it is
                 // non blocking.
                 thread(start = true) {
-                    while (true) {}
+                    while (state != ProtocolState.CLOSE) {}
                 }
             } catch (e: Exception) {
                 when (e) {
@@ -198,11 +204,12 @@ open class WebSocket : AbstractProtocol {
     override fun disconnect() {
         if (state != ProtocolState.CLOSE) {
             state = ProtocolState.CLOSE
-            trigger("networkStateChange", arrayOf(ProtocolState.CLOSE.toString()))
+            trigger(NetworkStateChangeEvent(ProtocolState.CLOSE))
             stopRetryingToConnect.set(true)
             GlobalScope.launch {
                 ws?.close()
                 ws = null
+                client?.close()
             }
         }
     }

--- a/src/main/kotlin/io/kuzzle/sdk/protocol/WebSocket.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/protocol/WebSocket.kt
@@ -68,7 +68,7 @@ open class WebSocket : AbstractProtocol {
             return CompletableFuture.completedFuture(false)
 
         state = ProtocolState.RECONNECTING
-        trigger("networkStateChange", state.toString())
+        trigger("networkStateChange", arrayOf(state.toString()))
         return CompletableFuture.supplyAsync(
             fun(): Boolean {
                 var retryCount: Long = 0
@@ -101,7 +101,7 @@ open class WebSocket : AbstractProtocol {
             ws = this
             // @TODO Create enums for events
             state = ProtocolState.OPEN
-            trigger("networkStateChange", ProtocolState.OPEN.toString())
+            trigger("networkStateChange", arrayOf(ProtocolState.OPEN.toString()))
 
             thread(start = true) {
                 while (ws != null) {
@@ -119,9 +119,9 @@ open class WebSocket : AbstractProtocol {
                 for (frame in incoming) {
                     when (frame) {
                         // @TODO Create enums for events
-                        is Frame.Text -> super.trigger("messageReceived", frame.readText())
+                        is Frame.Text -> super.trigger("messageReceived", arrayOf(frame.readText()))
                         // @TODO Create enums for events
-                        is Frame.Binary -> super.trigger("messageReceived", frame.readBytes().toString())
+                        is Frame.Binary -> super.trigger("messageReceived", arrayOf(frame.readBytes().toString()))
                     }
                 }
             } catch (e: Exception) {
@@ -130,7 +130,7 @@ open class WebSocket : AbstractProtocol {
                     fun (success: Boolean) {
                         if (!success) {
                             state = ProtocolState.CLOSE
-                            trigger("networkStateChange", ProtocolState.CLOSE.toString())
+                            trigger("networkStateChange", arrayOf(ProtocolState.CLOSE.toString()))
                             ws = null
                         }
                         // reset stopRetryingToConnect
@@ -140,7 +140,7 @@ open class WebSocket : AbstractProtocol {
             }
             if (!skip) {
                 state = ProtocolState.CLOSE
-                trigger("networkStateChange", ProtocolState.CLOSE.toString())
+                trigger("networkStateChange", arrayOf(ProtocolState.CLOSE.toString()))
                 ws = null
             }
         }
@@ -198,7 +198,7 @@ open class WebSocket : AbstractProtocol {
     override fun disconnect() {
         if (state != ProtocolState.CLOSE) {
             state = ProtocolState.CLOSE
-            trigger("networkStateChange", ProtocolState.CLOSE.toString())
+            trigger("networkStateChange", arrayOf(ProtocolState.CLOSE.toString()))
             stopRetryingToConnect.set(true)
             GlobalScope.launch {
                 ws?.close()

--- a/src/test/kotlin/io/kuzzle/sdk/protocolTest/WebSocketTests.kt
+++ b/src/test/kotlin/io/kuzzle/sdk/protocolTest/WebSocketTests.kt
@@ -18,8 +18,7 @@ import org.junit.Test
 
 class WebSocketTests {
     inner class MockedSocket(host: String) : WebSocket(host) {
-        @KtorExperimentalAPI
-        var mockedClient: HttpClient
+        var mockedClient: HttpClient?
             get() = super.client
             set(value) {
                 super.client = value
@@ -27,8 +26,6 @@ class WebSocketTests {
     }
 
     private var socket: MockedSocket? = null
-
-    @KtorExperimentalAPI
     @Before
     fun setup() {
         socket = MockedSocket("localhost")


### PR DESCRIPTION
## What does this PR do ?

### Dependencies
Upgrade `ktor` dependencies to `1.6.8`
Upgrade gradle version to `7.4`
Rollback from `openjdk11` to `openjdk8`

### README
Describe that there are two protocols now [HTTP, Websocket]
Update dependencies list
Remove section about BINTRAY repository

### HTTP Protocol
Finalize HTTP Protocol implementation
HTTP Protocol is now using coroutines to avoid blocking the main thread while making HTTP Requests

### Websocket Protocol
The websocket protocol was not closed properly after calling `disconnect`.
This behaviour was preventing the processes using the SDK from stopping.
This is now fixed

### Enhance event system
The previous event system was limited, it was only possible to give one string argument to the event callback which was not ideal.

The new event system sends one `event object` per event type which allows us to easily implement new events in the future and add new properties to existing event without causing breaking changes

### Snippets Tests
Fix NullPointerException that was occuring during snippet tests because `System.getenv(<key>)` was returning null when an environement variable was not set
Remove `protocols` configuration from each snippet to use the global snippet config