### PR TITLE
Support RawJson in Body and fixes

### DIFF
--- a/src/main/kotlin/io/kuzzle/sdk/Kuzzle.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/Kuzzle.kt
@@ -80,7 +80,7 @@ open class Kuzzle {
 
         // If the message is empty, we take the requestId of the event,
         // to avoid error in fromMap function.
-        if(! jsonObject.containsKey("requestId") && event.requestId != null) {
+        if (! jsonObject.containsKey("requestId") && event.requestId != null) {
             jsonObject = jsonObject.plus("requestId" to event.requestId)
         }
 

--- a/src/main/kotlin/io/kuzzle/sdk/Kuzzle.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/Kuzzle.kt
@@ -65,7 +65,7 @@ open class Kuzzle {
 
     private fun onMessageReceived(event: MessageReceivedEvent) {
         val message = event.message
-        val jsonObject: Map<String?, Any?>
+        var jsonObject: Map<String?, Any?>
         try {
             jsonObject = JsonSerializer.deserialize(message) as Map<String?, Any?>
         } catch (e: Exception) {
@@ -77,6 +77,13 @@ open class Kuzzle {
             }
             return
         }
+
+        // If the message is empty, we take the requestId of the event,
+        // to avoid error in fromMap function.
+        if(! jsonObject.containsKey("requestId") && event.requestId != null) {
+            jsonObject = jsonObject.plus("requestId" to event.requestId)
+        }
+
         val response = Response().apply {
             fromMap(jsonObject)
         }

--- a/src/main/kotlin/io/kuzzle/sdk/controllers/RealtimeController.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/controllers/RealtimeController.kt
@@ -25,7 +25,7 @@ class RealtimeController(kuzzle: Kuzzle) : BaseController(kuzzle) {
     )
 
     init {
-        kuzzle.protocol.addListener<UnhandledResponseEvent>() {
+        kuzzle.protocol.addListener<UnhandledResponseEvent> {
             val response = Response().apply {
                 fromMap(JsonSerializer.deserialize(it.message) as Map<String?, Any?>)
             }
@@ -50,7 +50,7 @@ class RealtimeController(kuzzle: Kuzzle) : BaseController(kuzzle) {
             }
         }
 
-        kuzzle.protocol.addListener<NetworkStateChangeEvent>() {
+        kuzzle.protocol.addListener<NetworkStateChangeEvent> {
             if (it.state == ProtocolState.CLOSE) {
                 currentSubscriptions.clear()
             }

--- a/src/main/kotlin/io/kuzzle/sdk/coreClasses/http/Route.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/coreClasses/http/Route.kt
@@ -81,11 +81,11 @@ class Route {
                     if (verb == "GET") {
                         var bodyMap = KuzzleMap()
                         var body = request["body"]
-                        if(body != null) {
+                        if (body != null) {
                             if (body is RawJson) {
                                 body = JsonSerializer.deserialize(body.rawJson)
                             }
-                            bodyMap = KuzzleMap.from(body  as Map<String?, Any?>)
+                            bodyMap = KuzzleMap.from(body as Map<String?, Any?>)
                         }
                         queryArgs.putAll(bodyMap)
                     }

--- a/src/main/kotlin/io/kuzzle/sdk/coreClasses/http/Route.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/coreClasses/http/Route.kt
@@ -2,7 +2,6 @@ package io.kuzzle.sdk.coreClasses.http
 
 import io.kuzzle.sdk.coreClasses.exceptions.MissingURLParamException
 import io.kuzzle.sdk.coreClasses.json.JsonSerializer
-import io.kuzzle.sdk.coreClasses.json.RawJson
 import io.kuzzle.sdk.coreClasses.maps.KuzzleMap
 import io.kuzzle.sdk.coreClasses.serializer.StringSerializer
 import java.net.URLEncoder

--- a/src/main/kotlin/io/kuzzle/sdk/coreClasses/json/JsonSerializer.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/coreClasses/json/JsonSerializer.kt
@@ -8,7 +8,7 @@ import io.kuzzle.sdk.coreClasses.maps.KuzzleMap
 object JsonSerializer {
     private var gson: Gson? = null
     fun deserialize(rawJson: String?): Map<*, *> {
-        return if(rawJson == null || rawJson.isBlank()) {
+        return if (rawJson == null || rawJson.isBlank()) {
             KuzzleMap()
         } else {
             gson!!.fromJson(rawJson, Map::class.java)

--- a/src/main/kotlin/io/kuzzle/sdk/coreClasses/json/JsonSerializer.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/coreClasses/json/JsonSerializer.kt
@@ -3,11 +3,16 @@ package io.kuzzle.sdk.coreClasses.json
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import io.kuzzle.sdk.coreClasses.RequestPayload
+import io.kuzzle.sdk.coreClasses.maps.KuzzleMap
 
 object JsonSerializer {
     private var gson: Gson? = null
     fun deserialize(rawJson: String?): Map<*, *> {
-        return gson!!.fromJson(rawJson, Map::class.java)
+        return if(rawJson == null || rawJson.isBlank()) {
+            KuzzleMap()
+        } else {
+            gson!!.fromJson(rawJson, Map::class.java)
+        }
     }
 
     fun serialize(obj: Any): String {

--- a/src/main/kotlin/io/kuzzle/sdk/coreClasses/maps/KuzzleMap.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/coreClasses/maps/KuzzleMap.kt
@@ -9,7 +9,7 @@ class KuzzleMap : HashMap<String?, Any?> {
     /**
      * Create a new instance of CustomMap
      */
-    constructor() : super() {}
+    constructor() : super()
 
     /**
      * Create a new instance of CustomMap from a Map<String></String>,


### PR DESCRIPTION
- Support RawJson body type in requests.
- Avoid NPE when empty response.
- Avoid requestId missing error when empty response by
taking the requestId of the event.