### PR TITLE
fix: headers format in response

### DIFF
--- a/src/main/kotlin/io/kuzzle/sdk/Kuzzle.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/Kuzzle.kt
@@ -89,7 +89,7 @@ open class Kuzzle {
             response.requestId = eventRequestId
             response.status = event.status
             if (event.headers != null) {
-                response.headers = event.headers as Map<String?, Any?>
+                response.headers = event.getHeadersMap() as Map<String?, Any?>?
                 if (response.headers!!.containsKey("X-Kuzzle-Volatile")) {
                     response.Volatile = response.headers!!["X-Kuzzle-Volatile"] as Map<String?, Any?>?
                 }
@@ -103,11 +103,13 @@ open class Kuzzle {
             response.index = event.payload["index"] as String?
             response.collection = event.payload["collection"] as String?
         } else {
-            if (! jsonObject.containsKey("headers") && event.headers != null) {
-                jsonObject = jsonObject.plus("headers" to event.headers)
+            val jsonObjectEventHeaders = jsonObject.toMutableMap()
+            if (event.headers != null) {
+                jsonObjectEventHeaders["headers"] = event.getHeadersMap()
             }
+
             response.apply {
-                fromMap(jsonObject)
+                fromMap(jsonObjectEventHeaders)
             }
         }
 

--- a/src/main/kotlin/io/kuzzle/sdk/events/MessageReceivedEvent.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/events/MessageReceivedEvent.kt
@@ -8,8 +8,8 @@ data class MessageReceivedEvent(
     var status: Int = 200,
     var headers: Headers? = null
 ) {
-    fun getHeadersMap() : Map<String, String> {
-        if(headers == null) {
+    fun getHeadersMap(): Map<String, String> {
+        if (headers == null) {
             return emptyMap()
         }
         return headers!!.entries().associate { it.key to it.value.first() }

--- a/src/main/kotlin/io/kuzzle/sdk/events/MessageReceivedEvent.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/events/MessageReceivedEvent.kt
@@ -1,8 +1,17 @@
 package io.kuzzle.sdk.events
 
+import io.ktor.http.*
+
 data class MessageReceivedEvent(
     var message: String?,
     var payload: Map<String?, Any?> = emptyMap(),
     var status: Int = 200,
-    var headers: Map<String, List<String>>? = null
-)
+    var headers: Headers? = null
+) {
+    fun getHeadersMap() : Map<String, String> {
+        if(headers == null) {
+            return emptyMap()
+        }
+        return headers!!.entries().associate { it.key to it.value.first() }
+    }
+}

--- a/src/main/kotlin/io/kuzzle/sdk/protocol/Http.kt
+++ b/src/main/kotlin/io/kuzzle/sdk/protocol/Http.kt
@@ -228,7 +228,7 @@ open class Http : AbstractProtocol {
                         response.receive(),
                         payload,
                         response.status.value,
-                        response.headers.toMap()
+                        response.headers
                     )
                 )
             } catch (e: Exception) {
@@ -266,7 +266,7 @@ open class Http : AbstractProtocol {
                         response.receive(),
                         payload,
                         response.status.value,
-                        response.headers.toMap()
+                        response.headers
                     )
                 )
             } catch (e: Exception) {


### PR DESCRIPTION
- We have mixed formats in headers (map of string/list of strings, and map of string/string), we convert all in map of string, string.
